### PR TITLE
PKGBUILD formatting config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,3 @@ trim_trailing_whitespace = true
 indent_style = spaces
 indent_size = 2
 max_line_length = 100
-binary_next_line = true
-space_redirects = true
-keep_padding = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# archlinux-proaudio editorconfig
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[PKGBUILD]
+indent_style = spaces
+indent_size = 2
+max_line_length = 100
+binary_next_line = true
+space_redirects = true
+keep_padding = true

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 [![Build Status](https://ci.cbix.de/api/badges/osam-cologne/archlinux-proaudio/status.svg)](https://ci.cbix.de/osam-cologne/archlinux-proaudio)
 
 PKGBUILD files for the binary archlinux pro-audio OSAMC repository
+
+## Guidelines
+This project closely follows the [Arch package guidelines](https://wiki.archlinux.org/title/Arch_package_guidelines).
+To support packaging, convenient tools are being maintained in this repo.
+- [`.editorconfig`](https://editorconfig.org/) to ensure consistent formatting of PKGBUILDs in your editor (may need a plugin)
+- `tools/fmt.sh` to manually format the PKGBUILD files (needs [`shfmt`](https://archlinux.org/packages/community/x86_64/shfmt/) installed)
+- check the CI logs for hints:
+  - [`namcap`](https://wiki.archlinux.org/title/Namcap) analysis of PKGBUILD
+  - full build of the package in a [clean environment](https://wiki.archlinux.org/title/DeveloperWiki:Building_in_a_clean_chroot#Why)
+  - `namcap` analysis of the built package
+  - rebuild and basic analysis of [reproducibility](https://reproducible-builds.org/) using [`diffoscope`](https://diffoscope.org/)

--- a/packages/mamba/PKGBUILD
+++ b/packages/mamba/PKGBUILD
@@ -16,7 +16,6 @@ groups=('pro-audio')
 source=("https://github.com/brummer10/Mamba/files/6329780/${_projectname}_${pkgver}.tar.gz")
 sha256sums=('974403e08ab5d0bc92dcfad7cfdc4c95df87c5d8ca586794923bdb2254569838')
 
-
 build() {
   cd "${srcdir}/${_projectname}_${pkgver}"
   make

--- a/tools/fmt.sh
+++ b/tools/fmt.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Format PKGBUILD files
+#
 
 cd "${0%/*}/.."
 ROOT="$(pwd)"

--- a/tools/fmt.sh
+++ b/tools/fmt.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd "${0%/*}/.."
+ROOT="$(pwd)"
+
+shfmt -l -i 2 -sr -kp -w ${*:-packages/*/PKGBUILD}


### PR DESCRIPTION
This adds an `.editorconfig` to ensure consistent indentation (2 spaces) and (basic) formatting of PKGBUILDs. Also a script to format all PKGBUILDs using [`shfmt`](https://archlinux.org/packages/community/x86_64/shfmt/)

To check if your editor can recognize this file, see https://editorconfig.org/

Maybe someone knows a more powerful tool for linting/formatting PKGBUILDs with configurable best practices.