### PR TITLE
feat: add package 'klick' using releases from fork Allfifthstuning/klick

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -31,6 +31,11 @@ include_regex = '^r(\d+)_(\d+)_(\d+)$'
 from_pattern = '^r(\d+)_(\d+)_(\d+)$'
 to_pattern = '\1.\2.\3'
 
+[klick]
+source = "github"
+github = "Allfifthstuning/klick"
+use_max_tag = true
+
 [kpp]
 source = "github"
 github = "olegkapitonov/Kapitonov-Plugins-Pack"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -3,6 +3,7 @@
   "aether.lv2": "1.2.1",
   "jalv-select": "1.3",
   "jamulus": "3.8.2",
+  "klick": "0.14.2",
   "kpp": "1.2.1",
   "mamba": "2.2",
   "mclk.lv2": "0.2.1",

--- a/packages/klick/PKGBUILD
+++ b/packages/klick/PKGBUILD
@@ -25,6 +25,6 @@ build() {
 package() {
   depends+=(libjack.so liblo.so librubberband.so libsamplerate.so libsndfile.so)
   cd $pkgname-$pkgver
-  scons DESTDIR="${pkgdir}" install
+  scons DESTDIR="$pkgdir" install
   install -Dm644 doc/manual.html -t "$pkgdir"/usr/share/doc/$pkgname
 }

--- a/packages/klick/PKGBUILD
+++ b/packages/klick/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: OSAMC <https://github.com/osam-cologne/archlinux-proaudio>
+# Contributor: Daniel Appelt <daniel.appelt@gmail.com>
+# Contributor: Christoph Zeiler <rabyte*gmail>
+# Contributor: Philipp Überbacher <murks at lavabit dot com>
+# Contributor: Christopher Arndt <aur -at- chrisarndt -dot- de>
+
+pkgname=klick
+pkgver=0.14.2
+pkgrel=1
+pkgdesc='An advanced command line based metronome for JACK'
+arch=(x86_64 aarch64)
+url='http://das.nasophon.de/klick/'
+license=(GPL)
+depends=(glibc gcc-libs)
+makedepends=(boost jack liblo libsndfile rubberband scons)
+# Fork of upstream with Python 3 and SCons build fixes
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Allfifthstuning/klick/archive/refs/tags/$pkgver.tar.gz")
+sha256sums=('5d356b9b4f5abb39cea32fe435a7e5754cabb39f090a2af53dc8f0dfff0167a8')
+
+build() {
+  cd $pkgname-$pkgver
+  scons PREFIX="/usr"
+}
+
+package() {
+  depends+=(libjack.so liblo.so librubberband.so libsamplerate.so libsndfile.so)
+  cd $pkgname-$pkgver
+  scons DESTDIR="${pkgdir}" install
+  install -Dm644 doc/manual.html -t "$pkgdir"/usr/share/doc/$pkgname
+}


### PR DESCRIPTION
Since the last release of `klick` is so old it doesn't compile anymore, we need to apply a host of post-release patches. I tried creating a patch with all the changes in the upstream repo since the last release, but that doesn't apply cleanly to the files from the source distribution. This needs more work.