### PR TITLE
generate status badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/
 /.secrets.env
 /.drone.env
 /.tmp
+/out
+/out2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # archlinux-proaudio
 [![Build Status](https://ci.cbix.de/api/badges/osam-cologne/archlinux-proaudio/status.svg)](https://ci.cbix.de/osam-cologne/archlinux-proaudio)
+![x86_64](https://arch.osamc.de/proaudio/x86_64/badge-count.svg)
+![aarch64](https://arch.osamc.de/proaudio/aarch64/badge-count.svg)
 
 PKGBUILD files for the binary archlinux pro-audio OSAMC repository.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,6 +26,10 @@ Remember to update the `pkgrel` so your package update reaches the users!
 This step also fetches all required dependencies to a shared pacman cache in order to speed up successive
 package installs.
 
+The output of `makepkg --packagelist` is also used to create a list of all potential
+package files of all packages in the repo, which is [later used](#update-database)
+to remove old packages from the database.
+
 ### Build packages
 This builds all packages determined by the prepare step.
 
@@ -66,6 +70,8 @@ and can be [downloaded from the repo server](https://arch.osamc.de/proaudio/osam
 
 ### Update database
 This is basically using the stock `repo-add` and `repo-remove` which are shipped with Pacman.
+To keep the database clean, all entries which are not built by any PKGBUILD are
+removed. This prevents leftover entries from removed, renamed or merged packages.
 
 ### Publish
 The [Drone SCP Plugin](https://plugins.drone.io/appleboy/drone-scp/) is used to push the resulting files to

--- a/tools/README.md
+++ b/tools/README.md
@@ -63,7 +63,6 @@ The public key is exported using
 gpg --export --armor $KEY_ID > osamc.gpg
 ```
 and can be [downloaded from the repo server](https://arch.osamc.de/proaudio/osamc.gpg)
-```
 
 ### Update database
 This is basically using the stock `repo-add` and `repo-remove` which are shipped with Pacman.

--- a/tools/update-db.sh
+++ b/tools/update-db.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -x
+set -e
+shopt -s nullglob
 if [ -z $CI ]; then
     echo "Only run in CI"
     exit 1

--- a/tools/update-db.sh
+++ b/tools/update-db.sh
@@ -13,7 +13,7 @@ source /etc/makepkg.conf
 
 # Fetch current database
 cd "$ROOT"/out
-curl -fOs "https://arch.osamc.de/proaudio/${CARCH}/proaudio.{db,files}.tar.gz"
+curl -fO "https://arch.osamc.de/proaudio/${CARCH}/proaudio.{db,files}.tar.gz"
 
 # Cleanup old packages from db
 REMOVAL=()
@@ -34,4 +34,4 @@ repo-add proaudio.db.tar.gz *$PKGEXT
 # Generate badge
 COUNT=$(bsdtar -tf proaudio.db.tar.gz '*/desc' | wc -l)
 BADGE="${CARCH/_/__}_packages-${COUNT}-informational"
-curl -fso badge-count.svg https://img.shields.io/badge/${BADGE}
+curl -fo badge-count.svg https://img.shields.io/badge/${BADGE}


### PR DESCRIPTION
[**Preview**](https://github.com/osam-cologne/archlinux-proaudio/blob/feat/badges/README.md#archlinux-proaudio)
![x86_64](https://arch.osamc.de/proaudio/x86_64/badge-count.svg)
![aarch64](https://arch.osamc.de/proaudio/aarch64/badge-count.svg)

These are generated when updating the database.

This also fixes a wrong code-fence in the tools README and improves documentation.