### PR TITLE
improve nvchecker patterns and CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -135,6 +135,7 @@ steps:
 
   - name: Sign packages
     image: plugins/gpgsign
+    pull: if-not-exists
     settings:
       key:
         from_secret: pkgsignkey
@@ -168,6 +169,7 @@ steps:
 
   - name: Publish
     image: appleboy/drone-scp
+    pull: if-not-exists
     settings:
       host: arch.osamc.de
       user: aiwahpoo
@@ -255,6 +257,7 @@ steps:
 
   - name: Sign packages
     image: plugins/gpgsign
+    pull: if-not-exists
     settings:
       key:
         from_secret: pkgsignkey
@@ -288,6 +291,7 @@ steps:
 
   - name: Publish
     image: appleboy/drone-scp
+    pull: if-not-exists
     settings:
       host: arch.osamc.de
       user: aiwahpoo
@@ -317,48 +321,3 @@ trigger:
       - refs/heads/master
       - refs/pull/**
       - refs/tags/**
-
-# CI maintenance pipelines
----
-kind: pipeline
-type: docker
-name: Update amd64 images
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-  - name: Update archlinux image
-    image: archlinux/archlinux:base-devel
-    pull: always
-    commands:
-      - echo Image updated
-
-trigger:
-  event:
-    - cron
-  cron:
-    - monthly
-
----
-kind: pipeline
-type: docker
-name: Update arm64 images
-
-platform:
-  os: linux
-  arch: arm64
-
-steps:
-  - name: Update archlinux image
-    image: lopsided/archlinux:devel
-    pull: always
-    commands:
-      - echo Image updated
-
-trigger:
-  event:
-    - cron
-  cron:
-    - monthly

--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -43,7 +43,7 @@ prefix = "v"
 [tuxguitar]
 source = "regex"
 url = "https://sourceforge.net/projects/tuxguitar/rss?path=/TuxGuitar"
-regex = 'tuxguitar-(.+)-src.tar.gz'
+regex = 'tuxguitar-(\d+\.\d+(?:\.\d+)?)-src.tar.gz'
 encoding = "utf-8"
 
 [ykchorus]

--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -7,23 +7,20 @@ newver = "new_ver.json"
 source = "github"
 github = "brummer10/Mamba"
 use_max_tag = true
-from_pattern = '^v'
-to_pattern = ""
+prefix = "v"
 
-[mclk-lv2]
-# note: dots in section names cause errors
+# note: unquoted dots in section names cause errors
+["mclk.lv2"]
 source = "github"
 github = "x42/mclk.lv2"
 use_max_tag = true
-from_pattern = '^v'
-to_pattern = ""
+prefix = "v"
 
 [midiomatic]
 source = "github"
 github = "SpotlightKid/midiomatic"
 use_max_tag = true
-from_pattern = '^v'
-to_pattern = ""
+prefix = "v"
 
 [python-pyjacklib]
 source = "pypi"
@@ -41,18 +38,16 @@ pypi = "QJackCapture"
 source = "github"
 github = "jpcima/string-machine"
 use_max_tag = true
-from_pattern = '^v'
-to_pattern = ""
+prefix = "v"
 
 [tuxguitar]
 source = "regex"
-url = "http://www.tuxguitar.com.ar/download.html"
-regex = 'Latest Version (\d+\.\d+(?:\.\d+)?)'
+url = "https://sourceforge.net/projects/tuxguitar/rss?path=/TuxGuitar"
+regex = 'tuxguitar-(.+)-src.tar.gz'
 encoding = "utf-8"
 
 [ykchorus]
 source = "github"
 github = "SpotlightKid/ykchorus"
 use_max_tag = true
-from_pattern = '^v'
-to_pattern = ""
+prefix = "v"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -1,6 +1,6 @@
 {
   "mamba": "2.2",
-  "mclk-lv2": "0.2.1",
+  "mclk.lv2": "0.2.1",
   "midiomatic": "0.2.1",
   "python-pyjacklib": "0.1.1",
   "python-rtmidi": "1.4.9",


### PR DESCRIPTION
Today there were a few incidents where apparently the CI host could not reach the docker registry and fail the pipeline run. This should not happen as all used images are generally available locally already. For regular cache maintenance I'll eventually setup another solution outside of this repo :)