### PR TITLE
Package MIDIMonster

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -24,6 +24,12 @@ github = "x42/mclk.lv2"
 use_max_tag = true
 prefix = "v"
 
+[midimonster]
+source = "github"
+github = "cbdevnet/midimonster"
+use_max_tag = true
+prefix = "v"
+
 [midiomatic]
 source = "github"
 github = "SpotlightKid/midiomatic"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -2,6 +2,7 @@
   "jamulus": "3.8.2",
   "mamba": "2.2",
   "mclk.lv2": "0.2.1",
+  "midimonster": "0.6",
   "midiomatic": "0.2.1",
   "ola": "0.10.8",
   "python-pyjacklib": "0.1.1",

--- a/packages/midimonster/PKGBUILD
+++ b/packages/midimonster/PKGBUILD
@@ -10,11 +10,12 @@ arch=(x86_64 aarch64)
 url='https://midimonster.net/'
 license=(BSD)
 depends=()
-makedepends=(alsa-lib jack libevdev lua openssl python)
+makedepends=(alsa-lib jack libevdev lua ola openssl python)
 optdepends=('alsa-lib: for the ALSA MIDI backend'
             'jack: for the JACK backend'
             'libevdev: for the evdev backend'
             'lua: for the lua backend'
+            'ola: for the OLA backend'
             'openssl: for the MA Web Remote backend'
             'python: for the Python backend')
 groups=(pro-audio)
@@ -24,7 +25,10 @@ backup=("etc/$pkgname/$pkgname.cfg")
 
 build() {
   cd $pkgname-$pkgver
-  make PLUGINS=/usr/lib/$pkgname DEFAULT_CFG=/etc/$pkgname/$pkgname.cfg # full
+  # https://github.com/cbdevnet/midimonster/pull/110
+  CPPFLAGS="$CXXFLAGS -std=c++11" \
+    make PLUGINS=/usr/lib/$pkgname DEFAULT_CFG=/etc/$pkgname/$pkgname.cfg \
+    full
 }
 
 package() {

--- a/packages/midimonster/PKGBUILD
+++ b/packages/midimonster/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: OSAMC <https://github.com/osam-cologne/archlinux-proaudio>
+# Contributor: BrainDamage
+# Contributor: Florian Hülsmann <fh@cbix.de>
+
+pkgname=midimonster
+pkgver=0.6
+pkgrel=3
+pkgdesc='Multi-protocol control & translation software'
+arch=(x86_64 aarch64)
+url='https://midimonster.net/'
+license=(BSD)
+depends=()
+makedepends=(alsa-lib jack libevdev lua openssl python)
+optdepends=('alsa-lib: for the ALSA MIDI backend'
+            'jack: for the JACK backend'
+            'libevdev: for the evdev backend'
+            'lua: for the lua backend'
+            'openssl: for the MA Web Remote backend'
+            'python: for the Python backend')
+groups=(pro-audio)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/cbdevnet/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('69d4450e1f341975b79b248931a6d4f959f1f979f8845e4eb4ffc179b6de9ae4')
+backup=("etc/$pkgname/$pkgname.cfg")
+
+build() {
+  cd $pkgname-$pkgver
+  make PLUGINS=/usr/lib/$pkgname DEFAULT_CFG=/etc/$pkgname/$pkgname.cfg # full
+}
+
+package() {
+  cd $pkgname-$pkgver
+  make DESTDIR="$pkgdir" install
+  install -vDm644 LICENSE.txt -t "$pkgdir"/usr/share/licenses/$pkgname
+  install -vDm644 assets/$pkgname.1 -t "$pkgdir"/usr/share/man/man1
+  # workaround for https://github.com/cbdevnet/midimonster/pull/109
+  install -vDm644 monster.cfg "$pkgdir"/etc/${pkgname}/${pkgname}.cfg
+}


### PR DESCRIPTION
[**MIDIMonster**](https://github.com/cbdevnet/midimonster)

Regarding the depends/optdepends:
(see [building instructions](https://github.com/cbdevnet/midimonster#building-from-source))
midimonster comes with a selection of backends, some of which link to shared libs like alsa or jack. If a backend can't run because of a missing dependency, it will simply be ignored and print a fail info:
```
MIDIMonster v0.6-dist
Failed to load plugin /usr/lib/midimonster/jack.so: libjack.so.0: cannot open shared object file: No such file or directory
Registered backend openpixelcontrol
Failed to load plugin /usr/lib/midimonster/evdev.so: libevdev.so.2: cannot open shared object file: No such file or directory
Registered backend rtpmidi
Registered backend mqtt
...
```
The working backends are usable, hence the idea to pull in _everything_ as optdepends. People will have most of these shared libs installed anyway, but not requiring all of them allows for a more stripped-down system. I can imagine it's popular to run this on a RasPi or similar, where you don't want to install tons of stuff.

I might eventually add a [libola](https://github.com/OpenLightingProject/ola) package so we can also build this with DMX support 🚥