### PR TITLE
Simple website

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -324,3 +324,35 @@ trigger:
       - refs/heads/master
       - refs/pull/**
       - refs/tags/**
+
+---
+kind: pipeline
+type: docker
+name: Website
+
+steps:
+  - name: Fetch databases
+    image: archlinux/archlinux:base-devel
+    commands:
+      - for ARCH in x86_64 aarch64; do
+        mkdir -p .tmp/db/$ARCH &&
+        curl https://arch.osamc.de/proaudio/$ARCH/proaudio.files.tar.gz |
+        bsdtar -xC .tmp/db/$ARCH; done
+
+  - name: Build site
+    image: klakegg/hugo:busybox
+    commands:
+      - hugo
+
+  - name: Publish
+    image: appleboy/drone-scp
+    pull: if-not-exists
+    settings:
+      host: arch.osamc.de
+      user: aiwahpoo
+      key:
+        from_secret: ssh-key
+      source: .tmp/public
+      target: /var/www/virtual/aiwahpoo/html/hugo-test
+      strip_components: 2
+      overwrite: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -353,6 +353,20 @@ steps:
       key:
         from_secret: ssh-key
       source: .tmp/public
-      target: /var/www/virtual/aiwahpoo/html/hugo-test
+      target: /var/www/virtual/aiwahpoo/html
       strip_components: 2
       overwrite: true
+
+depends_on:
+  - Build and check
+  - Build arm64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+
+when:
+  status:
+    - success
+    - failure

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/
 /.tmp
 /out
 /out2
+/.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 PKGBUILD files for the binary archlinux pro-audio OSAMC repository.
 
+[**List of packages**](https://arch.osamc.de/#packages)
+
 The repository is maintained and tested for both `x86_64` and `aarch64` (Arch Linux ARM) architectures.
 
 Contributions are welcome!
@@ -29,15 +31,3 @@ Import and sign locally:
 # pacman-key --lsign-key 762AE5DB2B38786364BD81C4B9141BCC62D38EE5
 ```
 You can now install packages from the repo using `pacman -Sy`.
-
-## Guidelines
-This project closely follows the [Arch package guidelines](https://wiki.archlinux.org/title/Arch_package_guidelines).
-To support packaging, convenient tools are being maintained in this repo.
-- [`.editorconfig`](https://editorconfig.org/) to ensure consistent formatting of PKGBUILDs in your editor (may need a plugin)
-- `tools/fmt.sh` to manually format the PKGBUILD files (needs [`shfmt`](https://archlinux.org/packages/community/x86_64/shfmt/) installed)
-- An [nvchecker](https://nvchecker.readthedocs.io/en/latest/) config with patterns for all included packages.
-- check the CI logs for hints:
-  - [`namcap`](https://wiki.archlinux.org/title/Namcap) analysis of PKGBUILD
-  - full build of the package in a [clean environment](https://wiki.archlinux.org/title/DeveloperWiki:Building_in_a_clean_chroot#Why)
-  - `namcap` analysis of the built package
-  - rebuild and basic analysis of [reproducibility](https://reproducible-builds.org/) using [`diffoscope`](https://diffoscope.org/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![x86\_64](https://arch.osamc.de/proaudio/x86_64/badge-count.svg)](https://arch.osamc.de/#packages)
 [![aarch64](https://arch.osamc.de/proaudio/aarch64/badge-count.svg)](https://arch.osamc.de/#packages)
 
-PKGBUILD files for the binary archlinux pro-audio OSAMC repository.
+Actively maintained binary package repo for Arch Linux of free and open source pro-audio software.
 
 [**List of packages**](https://arch.osamc.de/#packages) | [**GitHub repo**](https://github.com/osam-cologne/archlinux-proaudio/)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # archlinux-proaudio
 [![Build Status](https://ci.cbix.de/api/badges/osam-cologne/archlinux-proaudio/status.svg)](https://ci.cbix.de/osam-cologne/archlinux-proaudio)
-[![x86_64](https://arch.osamc.de/proaudio/x86_64/badge-count.svg)](https://arch.osamc.de/proaudio/x86_64/?P=*.pkg.tar.zst)
-[![aarch64](https://arch.osamc.de/proaudio/aarch64/badge-count.svg)](https://arch.osamc.de/proaudio/aarch64/?P=*.pkg.tar.xz)
+[![x86\_64](https://arch.osamc.de/proaudio/x86_64/badge-count.svg)](https://arch.osamc.de/#packages)
+[![aarch64](https://arch.osamc.de/proaudio/aarch64/badge-count.svg)](https://arch.osamc.de/#packages)
 
 PKGBUILD files for the binary archlinux pro-audio OSAMC repository.
 
-[**List of packages**](https://arch.osamc.de/#packages)
+[**List of packages**](https://arch.osamc.de/#packages) | [**GitHub repo**](https://github.com/osam-cologne/archlinux-proaudio/)
 
 The repository is maintained and tested for both `x86_64` and `aarch64` (Arch Linux ARM) architectures.
 
@@ -21,13 +21,9 @@ Add the repo to your `/etc/pacman.conf`:
 [proaudio]
 Server = https://arch.osamc.de/$repo/$arch
 ```
-Download the current signing key:
+Download, import and sign the current signing key:
 ```
-$ wget https://arch.osamc.de/proaudio/osamc.gpg
-```
-Import and sign locally:
-```
-# pacman-key --add osamc.gpg
+# curl https://arch.osamc.de/proaudio/osamc.gpg | pacman-key --add -
 # pacman-key --lsign-key 762AE5DB2B38786364BD81C4B9141BCC62D38EE5
 ```
 You can now install packages from the repo using `pacman -Sy`.

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,25 @@
+# Hugo static site generator config
+---
+baseURL: https://arch.osamc.de/
+languageCode: en-us
+title: Arch Linux Pro-Audio Repo
+publishDir: .tmp/public
+resourceDir: .tmp/resources
+module:
+  mounts:
+    - source: web/content
+      target: content
+    - source: web/static
+      target: static
+    - source: web/layouts
+      target: layouts
+    - source: web/data
+      target: data
+    - source: web/assets
+      target: assets
+    - source: web/i18n
+      target: i18n
+    - source: web/archetypes
+      target: archetypes
+minify:
+  minifyOutput: true

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,10 @@
 # Hugo static site generator config
 ---
+params:
+  bannerImage: https://unsplash.com/photos/19u5e9oSrlU/download
+  repoUrl: https://arch.osamc.de/proaudio/%s/%s
+  pkgbuildUrl: https://github.com/osam-cologne/archlinux-proaudio/blob/master/packages/%s/PKGBUILD
+
 baseURL: https://arch.osamc.de/
 languageCode: en-us
 title: Arch Linux Pro-Audio Repo

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,5 +1,17 @@
 # Behind the scenes
 
+## Guidelines
+This project closely follows the [Arch package guidelines](https://wiki.archlinux.org/title/Arch_package_guidelines).
+To support packaging, convenient tools are being maintained in this repo.
+- [`.editorconfig`](https://editorconfig.org/) to ensure consistent formatting of PKGBUILDs in your editor (may need a plugin)
+- `tools/fmt.sh` to manually format the PKGBUILD files (needs [`shfmt`](https://archlinux.org/packages/community/x86_64/shfmt/) installed)
+- An [nvchecker](https://nvchecker.readthedocs.io/en/latest/) config with patterns for all included packages.
+- check the CI logs for hints:
+  - [`namcap`](https://wiki.archlinux.org/title/Namcap) analysis of PKGBUILD
+  - full build of the package in a [clean environment](https://wiki.archlinux.org/title/DeveloperWiki:Building_in_a_clean_chroot#Why)
+  - `namcap` analysis of the built package
+  - rebuild and basic analysis of [reproducibility](https://reproducible-builds.org/) using [`diffoscope`](https://diffoscope.org/)
+
 ## Continuous Integration
 
 Most of the tools in this directory are being used by the CI Build / Check / Publish pipeline,

--- a/web/content/_footer.md
+++ b/web/content/_footer.md
@@ -1,0 +1,4 @@
+© 2022 [OSAMC](https://osamc.de/).
+Website theme: [water.css](https://github.com/kognise/water.css) Copyright © 2019 Kognise.
+Banner photo by [Sting Alleman](https://unsplash.com/@stingalleman) on [Unsplash](https://unsplash.com/photos/19u5e9oSrlU/).
+Website and packaging code are released into the public domain, see [LICENSE](https://github.com/osam-cologne/archlinux-proaudio/blob/master/LICENSE).

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -35,6 +35,12 @@
       .dir, .makedep, .checkdep {
         color: var(--text-muted);
       }
+      tr.summary.aarch64 {
+        display: none;
+      }
+      #aarch64:checked ~ table.packages tr.summary.aarch64 {
+        display: table-row;
+      }
     </style>
     {{ $banner := resources.GetRemote .Site.Params.bannerImage }}
     {{ $banner = $banner.Fill "800x200 Center" }}
@@ -42,6 +48,8 @@
     {{ $packages := partial "get-packages" }}
     {{ .RenderString (os.ReadFile "README.md") }}
     <h2 id="packages">List of packages</h2>
+    <input type="checkbox" name="aarch64" id="aarch64"/>
+    <label for="aarch64">Show aarch64 packages</label>
     <table class="packages">
       <thead>
         <tr>

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     {{ $water := resources.GetRemote "https://cdn.jsdelivr.net/npm/water.css@2/out/water.min.css" }}
-    <link rel="stylesheet" href="{{ $water.Permalink }}">
+    <link rel="stylesheet" href="{{ $water.RelPermalink }}">
   </head>
   <body>
     {{ $packages := partial "get-packages" }}

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.min.css">
+  </head>
+  <body>
+    {{ $packages := partial "get-packages" }}
+    {{ .RenderString (os.ReadFile "README.md") }}
+    <h1 id="packages">List of packages</h1>
+    <style>
+      tr.summary:hover {
+        background-color: var(--background-alt);
+      }
+      tr.detail:not(:target) {
+        display: none;
+      }
+      tr.detail:target {
+        display: table-row;
+      }
+      th.desc {
+        width: 320px;
+      }
+      .dir, .makedep, .checkdep {
+        color: var(--text-muted);
+      }
+      table.details th {
+        width: 200px;
+      }
+    </style>
+    <table>
+      <thead>
+        <tr>
+          <th>Arch</th>
+          <th>Name</th>
+          <th>Version</th>
+          <th class="desc">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $packages }}
+        <tr class="summary {{ .arch }}">
+          <td>{{ .arch }}</td>
+          <td><a href="#{{ .arch }}/{{ .name }}">{{ .name }}</a></td>
+          <td>{{ .version }}</td>
+          <td>{{ .desc }}</td>
+        </tr>
+        <tr class="detail" id="{{ .arch }}/{{ .name }}">
+          <td colspan="4">
+            {{ partial "package-details" . }}
+          </td>
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.min.css">
+    {{ $water := resources.GetRemote "https://cdn.jsdelivr.net/npm/water.css@2/out/water.min.css" }}
+    <link rel="stylesheet" href="{{ $water.Permalink }}">
   </head>
   <body>
     {{ $packages := partial "get-packages" }}
@@ -25,6 +26,14 @@
         .desc {
           display: none;
         }
+      }
+      .files {
+        max-height: 500px;
+        overflow: auto;
+        word-break: break-all;
+      }
+      .dir,.file {
+        display: block;
       }
       .dir, .makedep, .checkdep {
         color: var(--text-muted);

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -18,17 +18,19 @@
       tr.detail:target {
         display: table-row;
       }
-      th.desc {
-        width: 320px;
+      table.packages, table.details {
+        table-layout: auto;
+      }
+      @media(max-width: 576px) {
+        .desc {
+          display: none;
+        }
       }
       .dir, .makedep, .checkdep {
         color: var(--text-muted);
       }
-      table.details th {
-        width: 200px;
-      }
     </style>
-    <table>
+    <table class="packages">
       <thead>
         <tr>
           <th>Arch</th>
@@ -43,7 +45,7 @@
           <td>{{ .arch }}</td>
           <td><a href="#{{ .arch }}/{{ .name }}">{{ .name }}</a></td>
           <td>{{ .version }}</td>
-          <td>{{ .desc }}</td>
+          <td class="desc">{{ .desc }}</td>
         </tr>
         <tr class="detail" id="{{ .arch }}/{{ .name }}">
           <td colspan="4">

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -6,9 +6,6 @@
     <link rel="stylesheet" href="{{ $water.RelPermalink }}">
   </head>
   <body>
-    {{ $packages := partial "get-packages" }}
-    {{ .RenderString (os.ReadFile "README.md") }}
-    <h2 id="packages">List of packages</h2>
     <style>
       tr.summary:hover {
         background-color: var(--background-alt);
@@ -39,6 +36,12 @@
         color: var(--text-muted);
       }
     </style>
+    {{ $banner := resources.GetRemote .Site.Params.bannerImage }}
+    {{ $banner = $banner.Fill "800x200 Center" }}
+    <img class="banner" src="{{ $banner.RelPermalink }}" />
+    {{ $packages := partial "get-packages" }}
+    {{ .RenderString (os.ReadFile "README.md") }}
+    <h2 id="packages">List of packages</h2>
     <table class="packages">
       <thead>
         <tr>
@@ -64,5 +67,10 @@
         {{ end }}
       </tbody>
     </table>
+    <footer>
+      <small>
+        {{ .RenderString (os.ReadFile "web/content/_footer.md") }}
+      </small>
+    </footer>
   </body>
 </html>

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -7,7 +7,7 @@
   <body>
     {{ $packages := partial "get-packages" }}
     {{ .RenderString (os.ReadFile "README.md") }}
-    <h1 id="packages">List of packages</h1>
+    <h2 id="packages">List of packages</h2>
     <style>
       tr.summary:hover {
         background-color: var(--background-alt);

--- a/web/layouts/partials/filesize.html
+++ b/web/layouts/partials/filesize.html
@@ -1,0 +1,20 @@
+{{ $unit := 1000.0 }}
+{{ $size := float . }}
+{{ $res := printf "%.0f B" $size }}
+
+{{ if gt $size $unit }}
+  {{ $size = div $size $unit }}
+  {{ $res = printf "%.1f kB" $size }}
+{{ end }}
+
+{{ if gt $size $unit }}
+  {{ $size = div $size $unit }}
+  {{ $res = printf "%.1f MB" $size }}
+{{ end }}
+
+{{ if gt $size $unit }}
+  {{ $size = div $size $unit }}
+  {{ $res = printf "%.1f GB" $size }}
+{{ end }}
+
+{{ return $res }}

--- a/web/layouts/partials/get-packages.html
+++ b/web/layouts/partials/get-packages.html
@@ -1,0 +1,43 @@
+{{/*
+  This partial template parses the desc/files entries from the pacman databases.
+*/}}
+{{ $root := default ".tmp/db" . }}
+{{ $packages := newScratch }}
+
+{{ range where (os.ReadDir $root) "IsDir" true }}
+  {{ $dir := path.Join $root .Name }}
+  {{ range os.ReadDir $dir }}
+    {{ $pkgPath := path.Join $dir .Name }}
+
+    {{ $lines := (append
+      (split (os.ReadFile (path.Join $pkgPath "files")) "\n")
+      (split (os.ReadFile (path.Join $pkgPath "desc")) "\n")
+    ) | complement (slice "") }}
+
+    {{ $pkg := newScratch }}
+    {{ $key := "none" }}
+    {{ range $line := $lines }}
+      {{ if (findRE "^%.*%$" $line 1) }}
+        {{/* section key */}}
+        {{ $key = (lower (trim $line "%")) }}
+      {{ else if (in (slice "groups" "provides" "conflicts" "replaces" "license" "depends" "optdepends" "makedepends" "checkdepends" "files") $key) }}
+        {{/* array type */}}
+        {{ $pkg.Add $key (slice $line) }}
+      {{ else if (in (slice "csize" "isize") $key) }}
+        {{/* int type */}}
+        {{ $pkg.Set $key (int $line) }}
+      {{ else if (in (slice "builddate") $key) }}
+        {{/* timestamp */}}
+        {{ $pkg.Set $key (time (int $line)) }}
+      {{ else }}
+        {{/* string type */}}
+        {{ $pkg.Set $key $line }}
+      {{ end }}
+    {{ end }}
+
+    {{ with $pkg.Values }}
+      {{ $packages.Set (printf "%s-%s-%s" .name .version .arch) . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ return $packages.Values }}

--- a/web/layouts/partials/package-details.html
+++ b/web/layouts/partials/package-details.html
@@ -25,25 +25,25 @@
   {{ if .groups }}
   <tr>
     <th>Groups:</th>
-    <td>{{ range .groups }}{{ . }}<br/>{{ end }}</td>
+    <td>{{ range sort .groups }}{{ . }}<br/>{{ end }}</td>
   </tr>
   {{ end }}
   {{ if .provides }}
   <tr>
     <th>Provides:</th>
-    <td>{{ range .provides }}{{ . }}<br/>{{ end }}</td>
+    <td>{{ range sort .provides }}{{ . }}<br/>{{ end }}</td>
   </tr>
   {{ end }}
   {{ if .conflicts }}
   <tr>
     <th>Conflicts:</th>
-    <td>{{ range .conflicts }}{{ . }}<br/>{{ end }}</td>
+    <td>{{ range sort .conflicts }}{{ . }}<br/>{{ end }}</td>
   </tr>
   {{ end }}
   {{ if .replaces }}
   <tr>
     <th>Replaces:</th>
-    <td>{{ range .replaces }}{{ . }}<br/>{{ end }}</td>
+    <td>{{ range sort .replaces }}{{ . }}<br/>{{ end }}</td>
   </tr>
   {{ end }}
   <tr>
@@ -68,7 +68,7 @@
   <tr>
     <th>License{{ if gt (len .license) 1 }}s{{ end }}:</th>
     <td>
-      {{ range .license }}
+      {{ range sort .license }}
         {{ . }}<br/>
       {{ end }}
     </td>
@@ -81,22 +81,22 @@
     <th>Dependencies:</th>
     <td>
       {{ if .depends }}
-        {{ range .depends }}
+        {{ range sort .depends }}
           {{ . }}<br/>
         {{ end }}
       {{ end }}
       {{ if .optdepends }}
-        {{ range .optdepends }}
+        {{ range sort .optdepends }}
           {{ . }} <em>(optional)</em><br/>
         {{ end }}
       {{ end }}
       {{ if .makedepends }}
-        {{ range .makedepends }}
+        {{ range sort .makedepends }}
           <span class="makedep">{{ . }} <em>(make)</em></span><br/>
         {{ end }}
       {{ end }}
       {{ if .checkdepends }}
-        {{ range .checkdepends }}
+        {{ range sort .checkdepends }}
           <span class="checkdep">{{ . }} <em>(check)</em></span><br/>
         {{ end }}
       {{ end }}
@@ -105,7 +105,9 @@
 </table>
 <details>
   <summary><strong>Package Contents</strong></summary>
-  {{ range .files }}
-  <span class="{{ cond (strings.HasSuffix . `/`) `dir` `file` }}">{{ . }}</span><br/>
-  {{ end }}
+  <div class="files">
+    {{ range sort .files }}
+    <span class="{{ cond (strings.HasSuffix . `/`) `dir` `file` }}">{{ . }}</span>
+    {{ end }}
+  </div>
 </details>

--- a/web/layouts/partials/package-details.html
+++ b/web/layouts/partials/package-details.html
@@ -9,7 +9,7 @@
     <th>Base Package:</th>
     <td>
       {{ .base }}
-      (<a href="https://github.com/osam-cologne/archlinux-proaudio/blob/master/packages/{{ .base }}/PKGBUILD" target="_blank">PKGBUILD</a>)
+      (<a href="{{ printf site.Params.pkgbuildUrl .base }}" target="_blank">PKGBUILD</a>)
     </td>
   </tr>
   <tr>
@@ -58,7 +58,7 @@
           {{ $dlarch = "aarch64" }}
         {{ end }}
       {{ end }}
-      (<a href="https://arch.osamc.de/proaudio/{{ $dlarch }}/{{ .filename }}">Download</a>)
+      (<a href="{{ printf site.Params.repoUrl $dlarch .filename }}">Download</a>)
     </td>
   </tr>
   <tr>

--- a/web/layouts/partials/package-details.html
+++ b/web/layouts/partials/package-details.html
@@ -1,0 +1,111 @@
+<h3>{{ .name }} {{ .version }}</h3>
+<hr/>
+<table class="details">
+  <tr>
+    <th>Architecture:</th>
+    <td>{{ .arch }}</td>
+  </tr>
+  <tr>
+    <th>Base Package:</th>
+    <td>
+      {{ .base }}
+      (<a href="https://github.com/osam-cologne/archlinux-proaudio/blob/master/packages/{{ .base }}/PKGBUILD" target="_blank">PKGBUILD</a>)
+    </td>
+  </tr>
+  <tr>
+    <th>Description:</th>
+    <td>{{ .desc }}</td>
+  </tr>
+  {{ if .url }}
+  <tr>
+    <th>Upstream URL:</th>
+    <td><a href="{{ .url }}" target="_blank">{{ .url }}</a></td>
+  </tr>
+  {{ end }}
+  {{ if .groups }}
+  <tr>
+    <th>Groups:</th>
+    <td>{{ range .groups }}{{ . }}<br/>{{ end }}</td>
+  </tr>
+  {{ end }}
+  {{ if .provides }}
+  <tr>
+    <th>Provides:</th>
+    <td>{{ range .provides }}{{ . }}<br/>{{ end }}</td>
+  </tr>
+  {{ end }}
+  {{ if .conflicts }}
+  <tr>
+    <th>Conflicts:</th>
+    <td>{{ range .conflicts }}{{ . }}<br/>{{ end }}</td>
+  </tr>
+  {{ end }}
+  {{ if .replaces }}
+  <tr>
+    <th>Replaces:</th>
+    <td>{{ range .replaces }}{{ . }}<br/>{{ end }}</td>
+  </tr>
+  {{ end }}
+  <tr>
+    <th>Download Size:</th>
+    <td>
+      {{ partial "filesize" .csize }}
+      {{ $dlarch := .arch }}
+      {{ if (eq .arch "any") }}
+        {{ if (strings.HasSuffix .filename ".zst") }}
+          {{ $dlarch = "x86_64" }}
+        {{ else }}
+          {{ $dlarch = "aarch64" }}
+        {{ end }}
+      {{ end }}
+      (<a href="https://arch.osamc.de/proaudio/{{ $dlarch }}/{{ .filename }}">Download</a>)
+    </td>
+  </tr>
+  <tr>
+    <th>Installed Size:</th>
+    <td>{{ partial "filesize" .isize }}</td>
+  </tr>
+  <tr>
+    <th>License{{ if gt (len .license) 1 }}s{{ end }}:</th>
+    <td>
+      {{ range .license }}
+        {{ . }}<br/>
+      {{ end }}
+    </td>
+  </tr>
+  <tr>
+    <th>Build Date:</th>
+    <td>{{ dateFormat "2006-01-02 15:04 MST" .builddate.UTC}}</td>
+  </tr>
+  <tr>
+    <th>Dependencies:</th>
+    <td>
+      {{ if .depends }}
+        {{ range .depends }}
+          {{ . }}<br/>
+        {{ end }}
+      {{ end }}
+      {{ if .optdepends }}
+        {{ range .optdepends }}
+          {{ . }} <em>(optional)</em><br/>
+        {{ end }}
+      {{ end }}
+      {{ if .makedepends }}
+        {{ range .makedepends }}
+          <span class="makedep">{{ . }} <em>(make)</em></span><br/>
+        {{ end }}
+      {{ end }}
+      {{ if .checkdepends }}
+        {{ range .checkdepends }}
+          <span class="checkdep">{{ . }} <em>(check)</em></span><br/>
+        {{ end }}
+      {{ end }}
+    </td>
+  </tr>
+</table>
+<details>
+  <summary><strong>Package Contents</strong></summary>
+  {{ range .files }}
+  <span class="{{ cond (strings.HasSuffix . `/`) `dir` `file` }}">{{ . }}</span><br/>
+  {{ end }}
+</details>


### PR DESCRIPTION
This builds a simple static site using [Hugo](https://gohugo.io) to be pushed to https://arch.osamc.de/.

A preview can be tested under https://arch.osamc.de/hugo-test/, or run `hugo server` from the root dir. To render the package list it expects the [files databases](https://arch.osamc.de/proaudio/aarch64/proaudio.files.tar.gz) to be extracted to `.tmp/db/{x86_64,aarch64}`.

Closes #27 

## TODO
- [x] move some hard-coded strings to the config (repo URL, github link...)
- [x] add some contact information / footer section
- [x] maybe vendor the css lib
- [x] maybe make the table responsive for really small screens 👀
- [x] do SI file size units make sense?
  - yes, most file browsers use SI units
- [x] fix extra line breaks in Chrome
- [x] ~RSS feed for latest package updates~ will try that later