### PR TITLE
fix: checkdepends line was accidentally commented out

### DIFF
--- a/packages/string-machine/PKGBUILD
+++ b/packages/string-machine/PKGBUILD
@@ -4,14 +4,14 @@
 pkgname=string-machine
 _plugin_uri="http://jpcima.sdf1.org/lv2/$pkgname"
 pkgver=0.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A virtual-analog string ensemble synthesizer LV2 and VST2 plugin"
 arch=(x86_64 aarch64)
 url="https://github.com/jpcima/string-machine"
 license=(Boost)
 depends=(gcc-libs libx11 cairo)
 makedepends=(boost mesa)
-#checkdepends=(lv2lint)
+checkdepends=(kxstudio-lv2-extensions lv2lint)
 groups=(pro-audio lv2-plugins vst-plugins)
 _dpf_commit="05d91f5852f4bccfd2bce1d4d2e2b3036e29db03"
 source=("https://github.com/jpcima/string-machine/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
@@ -22,7 +22,7 @@ sha256sums=('5b0d2eb2185199c1de6c7c35700a2caafbc6ba564529a2e7614c15c3aceacc6f'
 prepare() {
   cd "$pkgname-$pkgver"
   # Update DPF base makefile to fix arm64 build
-  cp -f "$srcdir"/string-machine-Makefile.base.mk dpf/Makefile.base.mk
+  cp -f "$srcdir"/$pkgname-Makefile.base.mk dpf/Makefile.base.mk
 }
 
 build() {
@@ -33,7 +33,8 @@ build() {
 # generates too many errors, so ignore check failures
 check() {
   cd "$pkgname-$pkgver"
-  lv2lint -Mpack -I "bin/$pkgname.lv2/" "$_plugin_uri" ||
+  lv2lint -Mpack -s lv2_generate_ttl -t "Plugin Author Email" \
+    -I "bin/$pkgname.lv2/" "$_plugin_uri" ||
     echo "Ignoring lv2lint errors (known to fail)."
 }
 


### PR DESCRIPTION
* Add 'kxstudio-lv2-extensions' to checkdepends to get better lv2lint output.
* Ignore a few lv2lint warnings.
* Also replace occurrence of hard-coded literal package name with variable.