### PR TITLE
Package Kapitonov Plugins Pack

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -17,6 +17,12 @@ include_regex = '^r(\d+)_(\d+)_(\d+)$'
 from_pattern = '^r(\d+)_(\d+)_(\d+)$'
 to_pattern = '\1.\2.\3'
 
+[kpp]
+source = "github"
+github = "olegkapitonov/Kapitonov-Plugins-Pack"
+use_max_tag = true
+include_regex = '^\d+(\.\d+)+$'
+
 [mamba]
 source = "github"
 github = "brummer10/Mamba"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -1,6 +1,7 @@
 {
   "jalv-select": "1.3",
   "jamulus": "3.8.2",
+  "kpp": "1.2.1",
   "mamba": "2.2",
   "mclk.lv2": "0.2.1",
   "midimonster": "0.6",

--- a/packages/kpp/PKGBUILD
+++ b/packages/kpp/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: OSAMC <https://github.com/osam-cologne/archlinux-proaudio>
+# Contributor: Florian Hülsmann <fh@cbix.de>
+
+_projectname='Kapitonov-Plugins-Pack'
+pkgname=kpp
+pkgver=1.2.1
+pkgrel=1
+pkgdesc='Kapitonov Plugins Pack for guitar sound processing'
+arch=(x86_64 aarch64)
+url='https://kpp-tubeamp.com/'
+license=(GPL3)
+groups=(ladspa-plugins lv2-plugins pro-audio)
+depends=(cairo gcc-libs xcb-util xcb-util-wm)
+makedepends=(boost faust ladspa lv2 meson libxcb zita-convolver zita-resampler)
+optdepends=('ladspa-host: for running the LADSPA plugins'
+            'lv2-host: for running the LV2 plugins')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/olegkapitonov/$_projectname/archive/refs/tags/$pkgver.tar.gz")
+sha256sums=('056c152ee72c5a0cfd45ca0cd848ff13b098c8f58b14c26ad06d7ef49c792b40')
+
+build() {
+  cd $_projectname-$pkgver
+  # default flags are 'auto' so build wouldn't fail if dependencies are missing
+  meson build \
+    --prefix /usr \
+    -Dladspa=enabled \
+    -Dlv2=enabled \
+    -Dgui=enabled
+  ninja -C build
+}
+
+package() {
+  depends+=(libzita-convolver.so libzita-resampler.so)
+  cd $_projectname-$pkgver/build
+  DESTDIR="$pkgdir" meson install
+}

--- a/packages/kpp/PKGBUILD
+++ b/packages/kpp/PKGBUILD
@@ -18,18 +18,11 @@ source=("$pkgname-$pkgver.tar.gz::https://github.com/olegkapitonov/$_projectname
 sha256sums=('056c152ee72c5a0cfd45ca0cd848ff13b098c8f58b14c26ad06d7ef49c792b40')
 
 build() {
-  cd $_projectname-$pkgver
-  # default flags are 'auto' so build wouldn't fail if dependencies are missing
-  meson build \
-    --prefix /usr \
-    -Dladspa=enabled \
-    -Dlv2=enabled \
-    -Dgui=enabled
-  ninja -C build
+  arch-meson $_projectname-$pkgver build
+  meson compile -C build
 }
 
 package() {
   depends+=(libzita-convolver.so libzita-resampler.so)
-  cd $_projectname-$pkgver/build
-  DESTDIR="$pkgdir" meson install
+  meson install -C build --destdir "$pkgdir"
 }


### PR DESCRIPTION
[**Kapitonov Plugins Pack**](https://github.com/olegkapitonov/Kapitonov-Plugins-Pack) (LADSPA & LV2)

## TODO
- [ ] TBD: `kpp` (still free ;)) or `kapitonov-plugins-pack`?
  - maybe the `ssr` situation is a good example why more explicit = more better?
- [ ] make GUI runtime deps optional?
- [x] how to `check()` this? After `build()`, we only have the individual `.so`s but no ready to test LV2 bundles yet (those are put together by `meson install`)
  - `DESTDIR="test" meson install`
  - lots of lv2lint checks fail, including _Plugin Instantiation_. I believe there is no point now in adding the check there with exceptions as it will not help if in the future the plugins _actually_ break...
- [x] fix namcap errors
- [x] ~package [kpp-vst3](https://github.com/olegkapitonov/KPP-VST3)~ (requires vst3sdk)