### PR TITLE
Local drone cache for pacman and sources

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,6 +42,7 @@ steps:
       - name: pkgdb
         path: /var/lib/pacman/sync
     environment:
+      SRCDEST: /drone/src/.tmp/cache/srcdest
       PKGDEST: /drone/src/out
       MAKEFLAGS: -j4
     commands:
@@ -89,6 +90,7 @@ steps:
       - name: pkgdb
         path: /var/lib/pacman/sync
     environment:
+      SRCDEST: /drone/src/.tmp/cache/srcdest
       PKGDEST: /drone/src/out2
       MAKEFLAGS: -j4
     commands:

--- a/tools/build-env.sh
+++ b/tools/build-env.sh
@@ -7,7 +7,7 @@ echo '%nobody ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/nobody-sudo
 echo -e '[proaudio]\nSigLevel = Never\nServer = https://arch.osamc.de/$repo/$arch' >> /etc/pacman.conf
 source /etc/makepkg.conf
 export PACKAGER='OSAMC <https://github.com/osam-cologne/archlinux-proaudio>'
-export SRCDEST=/tmp/build
+export SRCDEST=${SRCDEST:-/tmp/build}
 export SRCPKGDEST=/tmp/build
 export BUILDDIR=/tmp/build
 export PKGDEST=${PKGDEST:-/tmp/build}


### PR DESCRIPTION
Closes #10 

When running the CI pipeline locally, there is now a `.tmp/cache` directory that persists subsequent runs and caches
- pacman packages
- pacman db
- downloaded sources

This should improve build time when the drone pipeline is used locally.