### PR TITLE
Package aether.lv2

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -3,6 +3,14 @@ oldver = "old_ver.json"
 newver = "new_ver.json"
 #keyfile = "keyfile.toml"
 
+# note: unquoted dots in section names cause errors
+["aether.lv2"]
+source = "github"
+github = "Dougal-s/Aether"
+use_max_tag = true
+include_regex = '^v[\.\d]+$'
+prefix = "v"
+
 [jalv-select]
 source = "github"
 github = "brummer10/jalv_select"
@@ -29,7 +37,6 @@ github = "brummer10/Mamba"
 use_max_tag = true
 prefix = "v"
 
-# note: unquoted dots in section names cause errors
 ["mclk.lv2"]
 source = "github"
 github = "x42/mclk.lv2"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -1,4 +1,5 @@
 {
+  "aether.lv2": "1.2.1",
   "jalv-select": "1.3",
   "jamulus": "3.8.2",
   "kpp": "1.2.1",

--- a/packages/aether.lv2/.gitignore
+++ b/packages/aether.lv2/.gitignore
@@ -1,0 +1,1 @@
+/checkout-1162d0e.patch

--- a/packages/aether.lv2/PKGBUILD
+++ b/packages/aether.lv2/PKGBUILD
@@ -11,7 +11,7 @@ url='https://dougal-s.github.io/Aether'
 license=(MIT)
 groups=(lv2-plugins pro-audio)
 depends=(gcc-libs libglvnd libx11)
-makedepends=(cmake glu)
+makedepends=(cmake glu md4c)
 checkdepends=(lv2lint)
 optdepends=('lv2-host: for running the plugin')
 _pugl_ref=9fd2cd2
@@ -43,6 +43,9 @@ build() {
     -DCMAKE_INSTALL_PREFIX='/usr' \
     -Wno-dev
   cmake --build build
+
+  cd $_projectname-$pkgver/usermanual
+  md2html -f --github USERMANUAL.md > index.html
 }
 
 check() {

--- a/packages/aether.lv2/PKGBUILD
+++ b/packages/aether.lv2/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: OSAMC <https://github.com/osam-cologne/archlinux-proaudio>
+# Contributor: Florian Hülsmann <fh@cbix.de>
+
+_projectname=Aether
+pkgname=aether.lv2
+pkgver=1.2.1
+pkgrel=1
+pkgdesc='An algorithmic reverb LV2 plugin based on Cloudseed'
+arch=(x86_64 aarch64)
+url='https://dougal-s.github.io/Aether'
+license=(MIT)
+groups=(lv2-plugins pro-audio)
+depends=(gcc-libs libglvnd libx11)
+makedepends=(cmake glu)
+checkdepends=(lv2lint)
+optdepends=('lv2-host: for running the plugin')
+_pugl_ref=9fd2cd2
+_nanovg_ref=077b65e
+source=("$_projectname-$pkgver.tar.gz::https://github.com/Dougal-s/$_projectname/archive/refs/tags/v$pkgver.tar.gz"
+        "pugl-$_pugl_ref.tar.gz::https://gitlab.com/lv2/pugl/-/archive/$_pugl_ref/pugl-$_pugl_ref.tar.gz"
+        "nanovg-$_nanovg_ref.tar.gz::https://github.com/memononen/nanovg/archive/$_nanovg_ref.tar.gz"
+        'checkout-1162d0e.patch::https://github.com/Dougal-s/Aether/compare/v1.2.1...1162d0e.patch')
+sha256sums=('9c377f9c1feb7fbee055ef2d0d733b6d37b11fe5d92064043afecf282b440a01'
+            '571763637ec95e85f8066ce0925de6075a1970cb8e1dbcdec61c702f6442d8f5'
+            'dc629e44703a84eba987eacfd45635bbeb48ec011a4b0e58c31fd7dc3c3485b7'
+            'a80569d0f3d28dd18b76681ef17e2a7d99450d30169f30ce2fda3425ef22a467')
+# these need to be extracted to the expected paths
+noextract=("pugl-$_pugl_ref.tar.gz" "nanovg-$_nanovg_ref.tar.gz")
+
+prepare() {
+  cd $_projectname-$pkgver
+  # extract submodules
+  bsdtar -xf ../pugl-$_pugl_ref.tar.gz -C extern/pugl --strip-components 1
+  bsdtar -xf ../nanovg-$_nanovg_ref.tar.gz -C extern/nanovg --strip-components 1
+
+  # A crash is already fixed in master
+  patch -Np1 -i ../checkout-1162d0e.patch
+}
+
+build() {
+  cmake -B build -S $_projectname-$pkgver \
+    -DCMAKE_BUILD_TYPE='Release' \
+    -DCMAKE_INSTALL_PREFIX='/usr' \
+    -Wno-dev
+  cmake --build build
+}
+
+check() {
+  lv2lint -Mpack -I build/$pkgname \
+    -t "UI Symbols" \
+    http://github.com/Dougal-s/Aether
+}
+
+package() {
+  depends+=(ttf-roboto)
+
+  cd $_projectname-$pkgver
+  install -vDm644 LICENSE.md -t "$pkgdir"/usr/share/licenses/$pkgname
+  install -vDm644 usermanual/* -t "$pkgdir"/usr/share/doc/$pkgname
+
+  cd "$srcdir"/build/$pkgname
+  install -vDm755 *.so -t "$pkgdir"/usr/lib/lv2/$pkgname
+  install -vDm644 *.ttl -t "$pkgdir"/usr/lib/lv2/$pkgname
+  install -d "$pkgdir"/usr/lib/lv2/$pkgname/fonts
+  ln -vs /usr/share/fonts/TTF/Roboto-{Light,Regular}.ttf -t "$pkgdir"/usr/lib/lv2/$pkgname/fonts
+}


### PR DESCRIPTION
[**Aether**](https://github.com/Dougal-s/Aether)

## TODO
- [x] add roboto ttf dependency and link from the .lv2 dir
  - pro: smaller install size if user already has roboto fonts installed
  - con: .lv2 is more system-dependent (should be ok for system-installed plugins tho)
  - con: namcap throws an error about this
- [x] fix dependencies
- [x] install license
- [x] should we package the user manual?
- [x] fix a crash that happens when disabling IN/OUT on the spectrogram (doesn't happen when building from git)
- [x] fix build of patched version on aarch64