### PR TITLE
Package swh-plugins.lv2

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -95,6 +95,12 @@ github = "jpcima/string-machine"
 use_max_tag = true
 prefix = "v"
 
+["swh-plugins.lv2"]
+source = "github"
+github = "swh/lv2"
+use_max_tag = true
+prefix = "v"
+
 [tuxguitar]
 source = "regex"
 url = "https://sourceforge.net/projects/tuxguitar/rss?path=/TuxGuitar"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -15,6 +15,7 @@
   "qjackcapture": "0.1.2",
   "stone-phaser": "0.1.2",
   "string-machine": "0.1.0",
+  "swh-plugins.lv2": "1.0.16",
   "tuxguitar": "1.5.5",
   "vcf-lv2": "0.0.2",
   "vcvrack": "2.1.0",

--- a/packages/swh-plugins.lv2/.gitignore
+++ b/packages/swh-plugins.lv2/.gitignore
@@ -1,0 +1,1 @@
+/fix-segfaults.patch

--- a/packages/swh-plugins.lv2/PKGBUILD
+++ b/packages/swh-plugins.lv2/PKGBUILD
@@ -12,11 +12,18 @@ license=(GPL3)
 groups=(lv2-plugins pro-audio)
 depends=()
 makedepends=(fftw libxslt)
-checkdepends=(kxstudio-lv2-extensions lilv lv2lint)
+checkdepends=(lilv lv2lint)
 optdepends=('lv2-host: for running the plugins')
 provides=(swh-plugins)
-source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz"
+        'fix-segfaults.patch::https://github.com/cbix/swh-lv2/compare/master...fix/activation-malloc.patch')
+sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548'
+            '529f886dee087beee11c5fdf052389c4efb6a1dbbc318821ba0571938282717b')
+
+prepare() {
+  cd $_name-$pkgver
+  patch -p1 -i ../fix-segfaults.patch
+}
 
 build() {
   cd $_name-$pkgver
@@ -26,7 +33,6 @@ build() {
 check() {
   _lv2path="$srcdir"/$_name-$pkgver/plugins
   for _plugin in $(LV2_PATH="$_lv2path" lv2ls 2>/dev/null); do
-    # several plugins are segfaulting in lv2lint
     LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack $_plugin \
       2>/dev/null || echo "Ignoring error (known to fail)"
   done

--- a/packages/swh-plugins.lv2/PKGBUILD
+++ b/packages/swh-plugins.lv2/PKGBUILD
@@ -10,7 +10,7 @@ arch=(x86_64 aarch64)
 url='http://plugin.org.uk/'
 license=(GPL3)
 groups=(lv2-plugins pro-audio)
-depends=()
+depends=(glibc)
 makedepends=(fftw libxslt)
 checkdepends=(lilv lv2lint)
 optdepends=('lv2-host: for running the plugins')
@@ -18,7 +18,7 @@ provides=(swh-plugins)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz"
         'fix-segfaults.patch::https://github.com/cbix/swh-lv2/compare/master...fix/activation-malloc.patch')
 sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548'
-            '0650535d69700da06b9887f715c5689327d5f4df0ed8c2292b0cb0092d3f807e')
+            '901bf0bb87d0cba518661f80bf64dc1e467629a59622a80b90c437674ada9f0c')
 
 prepare() {
   cd $_name-$pkgver

--- a/packages/swh-plugins.lv2/PKGBUILD
+++ b/packages/swh-plugins.lv2/PKGBUILD
@@ -16,12 +16,13 @@ checkdepends=(lilv lv2lint)
 optdepends=('lv2-host: for running the plugins')
 provides=(swh-plugins)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz"
-        'fix-segfaults.patch::https://github.com/cbix/swh-lv2/compare/master...fix/activation-malloc.patch')
+        "fix-segfaults.patch::https://patch-diff.githubusercontent.com/raw/swh/$_name/pull/18.patch")
 sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548'
             '901bf0bb87d0cba518661f80bf64dc1e467629a59622a80b90c437674ada9f0c')
 
 prepare() {
   cd $_name-$pkgver
+  # https://github.com/swh/lv2/pull/18
   patch -p1 -i ../fix-segfaults.patch
 }
 

--- a/packages/swh-plugins.lv2/PKGBUILD
+++ b/packages/swh-plugins.lv2/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: OSAMC <https://github.com/osam-cologne/archlinux-proaudio>
+# Contributor: Florian Hülsmann <fh@cbix.de>
+
+_name=lv2
+pkgname=swh-plugins.lv2
+pkgver=1.0.16
+pkgrel=1
+pkgdesc="LV2 port of Steve Harris' plugins suite"
+arch=(x86_64 aarch64)
+url='http://plugin.org.uk/'
+license=(GPL3)
+groups=(lv2-plugins pro-audio)
+depends=()
+makedepends=(fftw libxslt)
+checkdepends=(kxstudio-lv2-extensions lilv lv2lint)
+optdepends=('lv2-host: for running the plugins')
+provides=(swh-plugins)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548')
+
+build() {
+  cd $_name-$pkgver
+  make
+}
+
+check() {
+  _lv2path="$srcdir"/$_name-$pkgver/plugins
+  for _plugin in $(LV2_PATH="$_lv2path" lv2ls 2>/dev/null); do
+    # several plugins are segfaulting in lv2lint
+    LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack $_plugin \
+      2>/dev/null || echo "Ignoring error (known to fail)"
+  done
+}
+
+package() {
+  depends+=(libfftw3f.so)
+  cd $_name-$pkgver
+  make PREFIX="$pkgdir"/usr install-system
+}

--- a/packages/swh-plugins.lv2/PKGBUILD
+++ b/packages/swh-plugins.lv2/PKGBUILD
@@ -18,7 +18,7 @@ provides=(swh-plugins)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz"
         'fix-segfaults.patch::https://github.com/cbix/swh-lv2/compare/master...fix/activation-malloc.patch')
 sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548'
-            '41cf240a090c4bb094ec11b03ce3e2cc520856bac294cc144ab5ad7e30cb68f0')
+            '0650535d69700da06b9887f715c5689327d5f4df0ed8c2292b0cb0092d3f807e')
 
 prepare() {
   cd $_name-$pkgver
@@ -39,7 +39,7 @@ build() {
 check() {
   _lv2path="$srcdir"/$_name-$pkgver/plugins
   for _plugin in $(LV2_PATH="$_lv2path" lv2ls); do
-    LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack \
+    LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack -q \
       -t "Plugin Symbols" \
       -t "Plugin Version *" \
       -t "Port Properties" \

--- a/packages/swh-plugins.lv2/PKGBUILD
+++ b/packages/swh-plugins.lv2/PKGBUILD
@@ -18,7 +18,7 @@ provides=(swh-plugins)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swh/$_name/archive/refs/tags/v$pkgver.tar.gz"
         'fix-segfaults.patch::https://github.com/cbix/swh-lv2/compare/master...fix/activation-malloc.patch')
 sha256sums=('bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548'
-            '529f886dee087beee11c5fdf052389c4efb6a1dbbc318821ba0571938282717b')
+            '41cf240a090c4bb094ec11b03ce3e2cc520856bac294cc144ab5ad7e30cb68f0')
 
 prepare() {
   cd $_name-$pkgver
@@ -28,13 +28,23 @@ prepare() {
 build() {
   cd $_name-$pkgver
   make
+  # prevent lilv errors during check by removing unbuilt plugins
+  for _dir in plugins/*.lv2; do
+    if [ ! -e $_dir/manifest.ttl ]; then
+      rm -rf $_dir
+    fi
+  done
 }
 
 check() {
   _lv2path="$srcdir"/$_name-$pkgver/plugins
-  for _plugin in $(LV2_PATH="$_lv2path" lv2ls 2>/dev/null); do
-    LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack $_plugin \
-      2>/dev/null || echo "Ignoring error (known to fail)"
+  for _plugin in $(LV2_PATH="$_lv2path" lv2ls); do
+    LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack \
+      -t "Plugin Symbols" \
+      -t "Plugin Version *" \
+      -t "Port Properties" \
+      -t "Port Range" \
+      $_plugin
   done
 }
 


### PR DESCRIPTION
LV2 ports of [Steve Harris' plugins suite](http://plugin.org.uk/ladspa-swh/docs/ladspa-swh.html)

- segfaults in lv2lint caused by https://github.com/swh/lv2/issues/8
  - [x] patch to fix segfaults
  - [x] testing
  - [x] ~memcheck~
    - that can happen later and probably needs lots of attention
  - [x] open upstream PR
    - it's already merged now and swh is planning a release soon 🎉
- [x] ~build some extra plugins not included in the Makefile by default~
  - still getting a missing symbol error for `buffer_write` for some reason
  - not doing that for now