### PR TITLE
Remove pro-audio group from jamulus-headless

### DIFF
--- a/packages/jamulus/PKGBUILD
+++ b/packages/jamulus/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=jamulus
 pkgname=(jamulus jamulus-headless)
 pkgver=3.8.2
-pkgrel=4
+pkgrel=5
 pkgdesc="Internet jam session software"
 arch=(x86_64 aarch64)
 url='https://jamulus.io/'
@@ -48,6 +48,8 @@ package_jamulus() {
 }
 
 package_jamulus-headless() {
+  # prevent conflict when installing all pro-audio packages
+  groups=()
   cd $_pkgsrc
   pkgdesc+=" (headless server)"
   conflicts+=(jamulus)


### PR DESCRIPTION
This prevents a conflict when installing all packages from pro-audio. Thanks @jujudusud for reporting this.