### PR TITLE
feat: bump pkgrel due to protobuf soname bump

### DIFF
--- a/packages/ola/PKGBUILD
+++ b/packages/ola/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=ola
 pkgname=(ola ola-docs)
 pkgver=0.10.8
-pkgrel=1
+pkgrel=2
 pkgdesc='Open Lighting Architecture for controlling entertainment lighting equipment'
 arch=(x86_64 aarch64)
 url='https://www.openlighting.org'
@@ -24,7 +24,7 @@ build() {
     --enable-rdm-tests \
     --enable-ja-rule \
     --enable-e133
-    # --enable-java-libs \
+    # --enable-java-libs
   make
   make doxygen-doc
 }


### PR DESCRIPTION
```
Reading repository package databases...
Reading local package database...
:: installing protobuf (3.20.1-1) breaks dependency 'libprotobuf.so=30-64' required by ola
```