### PR TITLE
fix: nvchecker config and cron script

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -1,7 +1,7 @@
 [__config__]
 oldver = "old_ver.json"
 newver = "new_ver.json"
-#keyfile = "keyfile.toml"
+keyfile = "keyfile.toml"
 
 [abcm2ps]
 source = "github"

--- a/nvchecker/run-nvchecker.cron
+++ b/nvchecker/run-nvchecker.cron
@@ -6,6 +6,8 @@ CHECKOUT="$HOME/archlinux-proaudio"
 export PATH="$HOME/.local/bin:/usr/bin:/bin"
 
 cd "$CHECKOUT"
+git stash
 git pull -q
+git stash pop
 nvchecker -l warning
 $PYTHON nvchecker/nvchecker-notify-matrixchat.py # --dry-run


### PR DESCRIPTION
The notification script on the server couldn't pul the latest git commits, because the `nvchecker` config was changed locally.