### PR TITLE
vcvrack: add objcopy rule for aarch64

### DIFF
--- a/packages/vcvrack/PKGBUILD
+++ b/packages/vcvrack/PKGBUILD
@@ -8,7 +8,7 @@
 _name=Rack
 pkgname=vcvrack
 pkgver=2.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Open-source Eurorack modular synthesizer simulator'
 url='https://vcvrack.com/'
 license=(custom CCPL GPL3)
@@ -16,8 +16,8 @@ arch=(x86_64 aarch64)
 _plugin_name=Fundamental
 _plugin_ver=2.2.1
 _plugin_pkg=$pkgname-${_plugin_name,,}
-makedepends=(curl gendesk glew glfw-x11 jansson jq libarchive openssl rtaudio rtmidi simde speexdsp
-  zstd)
+depends=(glfw-x11 jansson openssl speexdsp)
+makedepends=(curl gendesk glew jq libarchive rtaudio rtmidi simde zstd)
 provides=(libRack.so $_plugin_pkg)
 conflicts=($_plugin_pkg)
 groups=(pro-audio)
@@ -55,7 +55,7 @@ sha256sums=('253b655a12bb4f27be8f134fee4696b328962ffb44413650dbad8656a123c9fd'
             '21ac35c6ad4e5a29c32939b17baaf7ac1936077eda2214e28675eefcf2021db8'
             'e1da6ccf04bae3a2101151fec7ddd32e48ff92b0a1146b559fd3221c778d521f'
             '1159629aa90abb7c972c0f630d55d018b88a6b3bc3ff0bb9466cc06982f38641'
-            '0046e7e7497f070fde1108267367f5eb25cd7a0d4268403d297036081da8abf5')
+            'bc6d144302e429d4a5051207733142e99c1c60953766d7d87b96f2b10a5ca723')
 # extract the submodules ourselves so we have control over the unpacked top-level directory name
 noextract=($(for _i in ${!_submodules[@]}; do
   echo "${_submodules[$_i]}-${_commits[$_i]}.tar.gz"
@@ -105,8 +105,8 @@ build() {
 
 package() {
   # Rack does not start with glfw-wayland
-  depends=(libcurl.so libGLEW.so glfw-x11 jansson libarchive.so
-    openssl librtaudio.so librtmidi.so libsamplerate.so speexdsp zenity)
+  depends+=(libcurl.so libGLEW.so libarchive.so
+    librtaudio.so librtmidi.so libsamplerate.so zenity)
   cd $_name-$pkgver
   install -vDm755 Rack -t "$pkgdir"/usr/lib/$pkgname
   install -vDm755 libRack.so -t "$pkgdir"/usr/lib

--- a/packages/vcvrack/aarch64.patch
+++ b/packages/vcvrack/aarch64.patch
@@ -13,7 +13,7 @@ index b2676f27..4b455a35 100644
  $(error Could not determine CPU architecture of $(MACHINE). Try hacking around in arch.mk)
  endif
 diff --git a/compile.mk b/compile.mk
-index 9580533c..70c171e6 100644
+index 9580533c..94b8a970 100644
 --- a/compile.mk
 +++ b/compile.mk
 @@ -14,7 +14,7 @@ FLAGS += -MMD -MP
@@ -25,6 +25,19 @@ index 9580533c..70c171e6 100644
  # Warnings
  FLAGS += -Wall -Wextra -Wno-unused-parameter
  # C++ standard
+@@ -82,8 +82,12 @@ build/%.m.o: %.m
+ build/%.bin.o: %
+ 	@mkdir -p $(@D)
+ ifdef ARCH_LIN
++ifdef ARCH_aarch64
++	$(OBJCOPY) -I binary -O elf64-littleaarch64 -B aarch64 --rename-section .data=.rodata,alloc,load,readonly,data,contents $< $@
++else
+ 	$(OBJCOPY) -I binary -O elf64-x86-64 -B i386:x86-64 --rename-section .data=.rodata,alloc,load,readonly,data,contents $< $@
+ endif
++endif
+ ifdef ARCH_WIN
+ 	$(OBJCOPY) -I binary -O pe-x86-64 -B i386:x86-64 --rename-section .data=.rodata,alloc,load,readonly,data,contents $< $@
+ endif
 diff --git a/dep.mk b/dep.mk
 index 1d541269..b7963885 100644
 --- a/dep.mk


### PR DESCRIPTION
fixes compiling some plugins on aarch64