### PR TITLE
update vcvrack-fundamental to v2.3.0

### DIFF
--- a/packages/vcvrack/PKGBUILD
+++ b/packages/vcvrack/PKGBUILD
@@ -8,17 +8,17 @@
 _name=Rack
 pkgname=vcvrack
 pkgver=2.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Open-source Eurorack modular synthesizer simulator'
 url='https://vcvrack.com/'
 license=(custom CCPL GPL3)
 arch=(x86_64 aarch64)
 _plugin_name=Fundamental
-_plugin_ver=2.2.1
+_plugin_ver=2.3.0
 _plugin_pkg=$pkgname-${_plugin_name,,}
 depends=(glfw-x11 jansson openssl speexdsp)
 makedepends=(curl gendesk glew jq libarchive rtaudio rtmidi simde zstd)
-provides=(libRack.so $_plugin_pkg)
+provides=("$_plugin_pkg=$_plugin_ver")
 conflicts=($_plugin_pkg)
 groups=(pro-audio)
 # use submodule_commits.sh to update this
@@ -50,8 +50,8 @@ sha256sums=('253b655a12bb4f27be8f134fee4696b328962ffb44413650dbad8656a123c9fd'
             'da6c2b5cd661dd1875af867e02bac4dee4e2db7ea6ed3e8a7fd840223d7ce642'
             'f5c5a814b3302ac865ab648ec69f586b67cc0e9d2e51f77bcd4f495e75af6930'
             'ca077ad436bcb5ffe579ee886b8e61c87e2ebd81fc762be02a9ca07235e219ff'
-            '5cb915e720e3ce2408c7ad5176a05be1f1fd149764ef6cf582cb6f9b967ab3f2'
-            'b5b33ecb74123bd24029a7936d48d93c8be441dac8258c81f07c780a2efa692f'
+            '5e34622b6a1e01d263d39f61b2bff5e9e85706bb69ae6ce8022ed463549892fe'
+            'd0d847a5dff1b8c1bfde209c8cf265096d0feb7e07e50b100b452be8cee1c9d6'
             '21ac35c6ad4e5a29c32939b17baaf7ac1936077eda2214e28675eefcf2021db8'
             'e1da6ccf04bae3a2101151fec7ddd32e48ff92b0a1146b559fd3221c778d521f'
             '1159629aa90abb7c972c0f630d55d018b88a6b3bc3ff0bb9466cc06982f38641'
@@ -100,7 +100,8 @@ build() {
   VERSION=$pkgver make -C dep includes
   VERSION=$pkgver make LDFLAGS+="$_ldflags" STANDALONE_LDFLAGS="$LDFLAGS"
   cd ../$_plugin_name-$_plugin_ver
-  VERSION=$_plugin_ver RACK_DIR=../$_name-$pkgver make dist
+  VERSION=$_plugin_ver RACK_DIR=../$_name-$pkgver \
+    LDFLAGS+=" $(pkg-config --libs samplerate)" make dist
 }
 
 package() {

--- a/packages/vcvrack/plugins.patch
+++ b/packages/vcvrack/plugins.patch
@@ -28,7 +28,7 @@ diff -aur a/plugin.mk b/plugin.mk
 +	# Installed includes
 +	FLAGS += -I/usr/include/vcvrack -I/usr/include/vcvrack/dep
 +	# Link shared libs
-+	LDFLAGS += -ldl $(shell pkg-config --libs glew glfw3 jansson libcurl openssl libarchive libzstd speexdsp samplerate rtmidi rtaudio)
++	LDFLAGS += -ldl
  	RACK_USER_DIR ?= $(HOME)/.Rack2
  endif
 


### PR DESCRIPTION
- update vcvrack-fundamental to v2.3.0
- remove broken `provides` because `libRack.so` does not actually have a `SONAME`
- add version to `vcvrack-fundamental` provide
- remove linking all libraries to plugins by default; plugins will have to link used libraries themselves