### PR TITLE
add jamulus to AUR list and bump pkgrel

### DIFF
--- a/aur/packages
+++ b/aur/packages
@@ -8,6 +8,7 @@ gnome-shell-extension-gsjackctl
 hpklinux
 jack-matchmaker
 jalv-select
+jamulus
 klick
 kpp
 mamba

--- a/packages/jamulus/PKGBUILD
+++ b/packages/jamulus/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=jamulus
 pkgname=(jamulus jamulus-headless)
 pkgver=3.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Internet jam session software"
 arch=(x86_64 aarch64)
 url='https://jamulus.io/'


### PR DESCRIPTION
Has osamc AUR user is enabled has maintainer in jamulus AUR repository, We want to use AUR like a mirror of osam repository.