### PR TITLE
fix: don't include CLAP plugin on aarch64 for now

### DIFF
--- a/packages/octasine/PKGBUILD
+++ b/packages/octasine/PKGBUILD
@@ -5,7 +5,7 @@
 _name=OctaSine
 pkgname=${_name,,}
 pkgver=0.8.3
-pkgrel=1
+pkgrel=2
 pkgdesc='A four-operator stereo FM synthesizer VST2 plugin'
 arch=(aarch64 x86_64)
 url='https://www.octasine.com/'
@@ -14,7 +14,6 @@ groups=(pro-audio vst-plugins)
 depends=(libx11 libxcb xcb-util-wm)
 makedepends=(libglvnd libxcursor python rust)
 optdepends=(
-  'clap-host: for loading the CLAP plugin'
   'vst-host: for loading the VST2 plugin'
 )
 source=("$pkgname-$pkgver.tar.gz::https://github.com/greatest-ape/$_name/archive/refs/tags/v$pkgver.tar.gz")
@@ -22,21 +21,37 @@ sha256sums=('8ddad2874165bd7d0b28f87c0d8cd7eb55021607deb79eed1f4e2890b13f003c')
 
 build() {
   cd $_name-$pkgver
-  cargo xtask bundle octasine --release
+  if [[ "$CARCH" = "aarch64" ]]; then
+    cargo xtask bundle octasine --release --no-default-features --features "glow vst2"
+  else
+    cargo xtask bundle octasine --release
+  fi
 }
 
 check() {
   cd $_name-$pkgver
-  cargo test
+  if [[ "$CARCH" = "aarch64" ]]; then
+    # test try to compile CLAP plugin as well, so don't run them on aarch64 for now
+    echo "Warning: skipping tests on $CARCH"
+  else
+    cargo test
+  fi
 }
 
 package() {
   depends+=(libGL.so)
+  if [[ "$CARCH" != "aarch64" ]]; then
+    optdepends+=('clap-host: for loading the CLAP plugin')
+  fi
   cd $_name-$pkgver
   # Use 'OctaSine' instead of 'octasine' a s the basename for the plugins
   # since that's what previous versions used, so that existing projects will still work.
   install -Dm755 target/bundled/$pkgname.so "$pkgdir"/usr/lib/vst/$_name.so
-  install -Dm755 target/bundled/$pkgname.clap "$pkgdir"/usr/lib/clap/$_name.clap
+
+  if [[ "$CARCH" != "aarch64" ]]; then
+    install -Dm755 target/bundled/$pkgname.clap "$pkgdir"/usr/lib/clap/$_name.clap
+  fi
+
   install -Dm644 *.md -t "$pkgdir"/usr/share/doc/$pkgname
   install -Dm644 images/* -t "$pkgdir"/usr/share/doc/$pkgname/images
 }


### PR DESCRIPTION
See: https://github.com/greatest-ape/OctaSine/issues/144