### PR TITLE
fix: /usr/sbin/sudo setuid permission bit

### DIFF
--- a/tools/build-env.sh
+++ b/tools/build-env.sh
@@ -16,4 +16,6 @@ export LOGDEST=${LOGDEST:-$PKGDEST}
 export SOURCE_DATE_EPOCH=${DRONE_BUILD_CREATED:-${DRONE_BUILD_STARTED:-$(date +%s)}}
 export HOME=/tmp
 mkdir -p .tmp/pkgs
+echo "Fixing sudo permissions"
+chmod u+s /usr/sbin/sudo
 alias run_nobody='PACKAGES="$(cd .tmp/pkgs; ls -1)" sudo -u nobody --preserve-env=HOME,CI,PACKAGER,PKGDEST,LOGDEST,SRCDEST,SRCPKGDEST,BUILDDIR,PACKAGE,PACKAGES,SOURCE_DATE_EPOCH,IGNOREDB,DRONE_TARGET_BRANCH,MAKEPKG_ARGS,MAKEFLAGS,DRONE_COMMIT_MESSAGE,PKGEXT'


### PR DESCRIPTION
It seems that `/usr/sbin/sudo` in the `archlinux/archlinux:base-devel` docker image used by the CI build steps suddenly does not have the correct permissions anymore.

As a workaround, we manually set the setuid bit in `tools/build-env.sh`.

Log of CI run with first occurrence of the issue: https://ci.cbix.de/osam-cologne/archlinux-proaudio/1260/1/2