### PR TITLE
updating Jamulus as upstream is releasing 3.10.0.

### DIFF
--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -23,7 +23,7 @@
   "ildaeil": "1.3",
   "jack-matchmaker": "0.11.0",
   "jalv-select": "1.3",
-  "jamulus": "3.9.1",
+  "jamulus": "3.10.0",
   "jkmeter": "0.9.0",
   "jmeters": "0.4.5",
   "klick": "0.14.2",

--- a/packages/jamulus/PKGBUILD
+++ b/packages/jamulus/PKGBUILD
@@ -19,7 +19,7 @@ groups=(pro-audio)
 source=("$pkgbase-$pkgver.tar.gz::https://github.com/jamulussoftware/$pkgbase/archive/r${pkgver//./_}.tar.gz"
   'jamulus.service'
   'jamulus.sysusers')
-sha256sums=('758381a92ff7b264534773b71b6bf8e098bbeb6d693efdc2916609f2ff842889'
+sha256sums=('671ce57431da1ffa701824cf945910f66f31a0260d08944a7d94bf2c67641f0c'
             '98e45f7f877dbc9f8113d63b6e009ff1025e73e1cce86f671b57474a4764e11f'
             '4117ad3a93b3211f679f93794b308ad292d1799a86f85a6b353cfdff8515e2f9')
 _pkgsrc=$pkgbase-r${pkgver//./_}

--- a/packages/jamulus/PKGBUILD
+++ b/packages/jamulus/PKGBUILD
@@ -5,8 +5,8 @@
 
 pkgbase=jamulus
 pkgname=(jamulus jamulus-headless)
-pkgver=3.9.1
-pkgrel=2
+pkgver=3.10.0
+pkgrel=1
 pkgdesc="Internet jam session software"
 arch=(x86_64 aarch64)
 url='https://jamulus.io/'


### PR DESCRIPTION
Hi everyone,

Jamulus is releasing 3.10.0 version.

This PR come to update our package also.

Let me know if everything is ok.

Thanks!