### PR TITLE
dxconvert: update to v3.2.1 and add to AUR list

### DIFF
--- a/aur/packages
+++ b/aur/packages
@@ -6,6 +6,7 @@ audiowmark
 clap-validator
 darkice
 die-plugins
+dxconvert
 elephantdsp-roomreverb
 fatfrog.lv2
 faustlive

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -10,7 +10,7 @@
   "convertwithmoss": "7.2.0",
   "darkice": "1.4",
   "die-plugins": "1.1",
-  "dxconvert": "3.2.0",
+  "dxconvert": "3.2.1",
   "elephantdsp-roomreverb": "1.1.0",
   "fatfrog.lv2": "1.0",
   "faustlive": "2.5.16",

--- a/packages/dxconvert/PKGBUILD
+++ b/packages/dxconvert/PKGBUILD
@@ -3,8 +3,8 @@
 
 _name=DXconvert
 pkgname=${_name,,}
-pkgver=3.2.0
-pkgrel=2
+pkgver=3.2.1
+pkgrel=1
 pkgdesc='A file conversion and manipulation toolkit for Yamaha FM synth patches'
 arch=(any)
 url='http://dxconvert.martintarenskeen.nl/'
@@ -18,8 +18,8 @@ optdepends=(
   'zbar: convert patches from QR codes to SysEx'
 )
 groups=(pro-audio)
-source=("http://home.kpn.nl/m.tarenskeen/download/sysex/$_name/$_name-$pkgver.zip")
-sha256sums=('d4f20b7ea6240fdbf5b91f74315d4490a72c780c2662131bbe911e3858ff406b')
+source=("https://dxconvert.martintarenskeen.nl/$_name-$pkgver.zip")
+sha256sums=('3495e3ee1f60e556001a7ab03dddec4fb190e2f1cbdc3f3503311d3f43181a21')
 
 prepare() {
   cd $_name-$pkgver

--- a/packages/dxconvert/PKGBUILD
+++ b/packages/dxconvert/PKGBUILD
@@ -4,7 +4,7 @@
 _name=DXconvert
 pkgname=${_name,,}
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A file conversion and manipulation toolkit for Yamaha FM synth patches'
 arch=(any)
 url='http://dxconvert.martintarenskeen.nl/'


### PR DESCRIPTION
@SpotlightKid not sure if it was left out intentionally, but since the AUR is outdated and already has osamc added as a maintainer, it makes sense to enable the sync as well