### PR TITLE
paulxstretch: fix patch sha256sum

### DIFF
--- a/packages/paulxstretch/PKGBUILD
+++ b/packages/paulxstretch/PKGBUILD
@@ -4,7 +4,7 @@
 _name=PaulXStretch
 pkgname=${_name,,}
 pkgver=1.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Extreme time stretching tool (standalone, VST3 and CLAP plugin)'
 arch=(aarch64 x86_64)
 url='https://sonosaurus.com/paulxstretch/'
@@ -19,7 +19,7 @@ groups=(clap-plugins pro-audio vst3-plugins)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/essej/$pkgname/archive/refs/tags/v$pkgver.tar.gz"
         'fix-juce-x11.patch::https://github.com/juce-framework/JUCE/commit/4f9a9c7b.patch')
 sha256sums=('460b569c64dc5be57a963b863adc1b2606dc14a264701d8c983df3d3b6f7944d'
-            '0786e34ce5b3db2047a6999dbe22d722df9344da9f0719d725beec9501d93d48')
+            '4dd7ce8eaba1f90c514c9689b63729db8ecc482f6fba087cef9a960792ce3a3b')
 
 prepare() {
   cd $pkgname-$pkgver/deps/juce

--- a/packages/simplescreenrecorder/.gitignore
+++ b/packages/simplescreenrecorder/.gitignore
@@ -1,0 +1,1 @@
+/ffmpeg5.patch


### PR DESCRIPTION
- fixes #364 
- for reference, the change was caused by github generating slightly longer commit hashes:
    ```diff
  --- paulxstretch/fix-juce-x11-2.patch	2024-02-04 14:48:03.554849412 +0100
  +++ paulxstretch/fix-juce-x11.patch	2024-02-18 22:29:40.740732297 +0100
  @@ -10,7 +10,7 @@
    3 files changed, 42 insertions(+), 11 deletions(-)
   
   diff --git a/BREAKING-CHANGES.txt b/BREAKING-CHANGES.txt
  -index 9cdbc6c910c..f9517ae9c8e 100644
  +index 9cdbc6c910c7..f9517ae9c8e7 100644
   --- a/BREAKING-CHANGES.txt
   +++ b/BREAKING-CHANGES.txt
   @@ -1,6 +1,28 @@
  @@ -43,7 +43,7 @@
    =============
    
   diff --git a/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp b/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
  -index 384005f9f53..3911d1d59be 100644
  +index 384005f9f53b..3911d1d59be1 100644
   --- a/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
   +++ b/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
   @@ -179,15 +179,21 @@ XWindowSystemUtilities::GetXProperty::~GetXProperty()
  @@ -92,7 +92,7 @@
    
    XWindowSystem::DisplayVisuals::DisplayVisuals (::Display* xDisplay)
   diff --git a/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.h b/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.h
  -index 9bc284a407d..9369f8244af 100644
  +index 9bc284a407d7..9369f8244af4 100644
   --- a/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.h
   +++ b/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.h
   @@ -130,7 +130,7 @@ namespace XWindowSystemUtilities
  ```