### PR TITLE
Fix clap-example-host and vcvrack for rtmidi 6

### DIFF
--- a/packages/clap-example-host/PKGBUILD
+++ b/packages/clap-example-host/PKGBUILD
@@ -5,13 +5,13 @@ _name=clap-host
 # clap-host as pkgname is not ideal due to other hosts using that as a virtual provides
 pkgname=clap-example-host
 pkgver=1.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc='CLAP example audio plugin host'
 arch=(aarch64 x86_64)
 url='https://github.com/free-audio/clap-host'
 license=(MIT)
 depends=(gcc-libs qt6-base)
-makedepends=(catch2 cmake rtaudio rtmidi)
+makedepends=(catch2-v2 cmake rtaudio rtmidi)
 provides=(clap-host)
 groups=(pro-audio)
 _clap_ref='d6cbd4f'

--- a/packages/vcvrack/PKGBUILD
+++ b/packages/vcvrack/PKGBUILD
@@ -8,7 +8,7 @@
 _name=Rack
 pkgname=vcvrack
 pkgver=2.4.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Open-source Eurorack modular synthesizer simulator'
 url='https://vcvrack.com/'
 license=(custom CCPL GPL3)


### PR DESCRIPTION
- Closes #370 
- This will likely break the update for Manjaro as they're still on rtmidi 5