### PR TITLE
feat: update package 'alsa-utils' to 1.2.5-1

### DIFF
--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -48,7 +48,7 @@
   "python-pysimplegui": "4.60.5",
   "python-soundfile": "0.12.1",
   "qjackcapture": "0.2.1",
-  "rakarrack-plus": "1.2.4",
+  "rakarrack-plus": "1.2.5",
   "raysession": "0.14.3",
   "rezonateur": "0.1.0",
   "rtcqs": "0.6.2",

--- a/packages/rakarrack-plus/PKGBUILD
+++ b/packages/rakarrack-plus/PKGBUILD
@@ -2,33 +2,33 @@
 # Contributor: Florian Hülsmann <fh@cbix.de>
 
 pkgname=rakarrack-plus
-pkgver=1.2.4
+pkgver=1.2.5
 pkgrel=1
 pkgdesc='Guitar Effects Processor'
 arch=(x86_64 aarch64)
 url='https://github.com/Stazed/rakarrack-plus'
-license=(GPL2)
-depends=(alsa-utils gcc-libs libxpm)
+license=(GPL-2.0-only)
+depends=(alsa-utils glibc gcc-libs libx11 libxpm)
 makedepends=(cmake fftw fltk jack liblo lv2 libsndfile python)
 checkdepends=(lilv lv2lint)
 optdepends=('lv2-host: for running LV2 plugins'
             'new-session-manager: for NSM support')
 groups=(lv2-plugins pro-audio)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/Stazed/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('e025996351d712b25636f6e643cb346f297696c5956935f990a79b1a6f08622a')
+sha256sums=('cccfdcbc1b068bbfa7641a832f14b89edac262aa5e1326109eb4f754239f5983')
 
 build() {
-  cmake -B build -S $pkgname-$pkgver \
+  cmake -B build-$pkgname-$pkgver -S $pkgname-$pkgver \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DEnableSysex=ON -DBuildCarlaPresets=ON \
     -Wno-dev
-  cmake --build build
+  cmake --build build-$pkgname-$pkgver
 }
 
 check() {
   mkdir -p "$srcdir"/test
-  DESTDIR="$srcdir"/test make -C build/lv2 install
+  DESTDIR="$srcdir"/test make -C build-$pkgname-$pkgver/lv2 install
   local _lv2path="$srcdir"/test/usr/lib/lv2
   local _plugins=($(LV2_PATH="$_lv2path" lv2ls))
   LV2_PATH="$_lv2path":/usr/lib/lv2 lv2lint -Mpack -d -q \
@@ -40,5 +40,5 @@ check() {
 package() {
   depends+=(libasound.so libfftw3.so libfftw3f.so libfltk.so libfltk_images.so libjack.so liblo.so
     libsamplerate.so libsndfile.so)
-  DESTDIR="$pkgdir" cmake --install build
+  DESTDIR="$pkgdir" cmake --install build-$pkgname-$pkgver
 }


### PR DESCRIPTION
* Set license to SPDX identifier.
* Added 'glibc' and 'libx11' to depends.
* Made cmake build dir name release-specific.