### PR TITLE
fix: remove nvchecker config for python-pysimplegui

### DIFF
--- a/nvchecker/archlinux-proaudio.toml
+++ b/nvchecker/archlinux-proaudio.toml
@@ -284,10 +284,6 @@ pypi = "mido"
 source = "pypi"
 pypi = "pyjacklib"
 
-[python-pysimplegui]
-source = "pypi"
-pypi = "PySimpleGUI"
-
 [python-soundfile]
 source = "pypi"
 pypi = "soundfile"

--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -45,7 +45,6 @@
   "python-miditk-smf": "0.3.1",
   "python-mido": "1.3.2",
   "python-pyjacklib": "0.1.1",
-  "python-pysimplegui": "4.60.5",
   "python-soundfile": "0.12.1",
   "qjackcapture": "0.2.1",
   "rakarrack-plus": "1.2.5",


### PR DESCRIPTION
Versions >= 5 are not FLOSS anymore