### PR TITLE
convertwithmoss: update to v8.5.1

### DIFF
--- a/nvchecker/old_ver.json
+++ b/nvchecker/old_ver.json
@@ -9,7 +9,7 @@
   "clap-example-host": "1.0.3",
   "clap-validator": "0.3.2",
   "collisiondrive.lv2": "0.1",
-  "convertwithmoss": "8.5.0",
+  "convertwithmoss": "8.5.1",
   "darkice": "1.4",
   "die-plugins": "1.1",
   "dxconvert": "3.2.1",

--- a/packages/convertwithmoss/PKGBUILD
+++ b/packages/convertwithmoss/PKGBUILD
@@ -15,7 +15,7 @@ makedepends=(maven)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/git-moss/ConvertWithMoss/archive/refs/tags/$pkgver.tar.gz"
         convertwithmoss.sh)
 sha256sums=('ed85ba80d0e10f3bcb8693e79612394e55a9aa59fa07d75051fe91411c17bc91'
-            '2fdfdd27e993349f78137f0e1bf1b06891638a787509924abe2c816775e34a09')
+            '119c190f92a96c3556b770d504ada91fc89d522e837bf490dd3c6b4577d7ca3d')
 
 build() {
   cd $_name-$pkgver

--- a/packages/convertwithmoss/PKGBUILD
+++ b/packages/convertwithmoss/PKGBUILD
@@ -4,7 +4,7 @@
 
 _name=ConvertWithMoss
 pkgname=${_name,,}
-pkgver=8.5.0
+pkgver=8.5.1
 pkgrel=1
 pkgdesc='A tool for converting multi-samples from one format to another'
 url='https://mossgrabers.de/Software/ConvertWithMoss/ConvertWithMoss.html'
@@ -13,7 +13,7 @@ license=(LGPL-3.0-only)
 depends=('java-runtime>=16')
 makedepends=(maven)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/git-moss/ConvertWithMoss/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('74110bf39177a90c2cc5c831ddcb517cc1331b69cf344cd6717a2c0047b12fa0')
+sha256sums=('ed85ba80d0e10f3bcb8693e79612394e55a9aa59fa07d75051fe91411c17bc91')
 
 build() {
   cd $_name-$pkgver

--- a/packages/convertwithmoss/PKGBUILD
+++ b/packages/convertwithmoss/PKGBUILD
@@ -12,8 +12,10 @@ arch=(aarch64 x86_64)
 license=(LGPL-3.0-only)
 depends=('java-runtime>=16')
 makedepends=(maven)
-source=("$pkgname-$pkgver.tar.gz::https://github.com/git-moss/ConvertWithMoss/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('ed85ba80d0e10f3bcb8693e79612394e55a9aa59fa07d75051fe91411c17bc91')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/git-moss/ConvertWithMoss/archive/refs/tags/$pkgver.tar.gz"
+        convertwithmoss.sh)
+sha256sums=('ed85ba80d0e10f3bcb8693e79612394e55a9aa59fa07d75051fe91411c17bc91'
+            '2fdfdd27e993349f78137f0e1bf1b06891638a787509924abe2c816775e34a09')
 
 build() {
   cd $_name-$pkgver
@@ -21,13 +23,13 @@ build() {
 }
 
 package() {
+  install -Dm755 $pkgname.sh "$pkgdir"/usr/bin/$pkgname
   cd $_name-$pkgver
-  install -Dm644 target/lib/*.jar -t "$pkgdir"/usr/share/$_name
-  ln -sf $pkgname-$pkgver.jar "$pkgdir"/usr/share/$_name/$pkgname.jar
+  install -Dm644 target/lib/*.jar -t "$pkgdir"/usr/share/java/$pkgname
+  ln -sf $pkgname-$pkgver.jar "$pkgdir"/usr/share/java/$pkgname/$pkgname.jar
   install -Dm644 linux/de.mossgrabers.$_name.desktop \
     -t "$pkgdir"/usr/share/applications
   install -Dm644 linux/de.mossgrabers.$_name.appdata.xml \
     -t "$pkgdir"/usr/share/metainfo
   install -Dm644 icons/$pkgname.png -t "$pkgdir"/usr/share/pixmaps
-  install -Dm755 linux/$pkgname.sh "$pkgdir"/usr/bin/$pkgname
 }

--- a/packages/convertwithmoss/convertwithmoss.sh
+++ b/packages/convertwithmoss/convertwithmoss.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/java -jar /usr/share/java/covertwithmoss/convertwithmoss.jar "$@"

--- a/packages/convertwithmoss/convertwithmoss.sh
+++ b/packages/convertwithmoss/convertwithmoss.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/bin/java -jar /usr/share/java/covertwithmoss/convertwithmoss.jar "$@"
+exec /usr/bin/java -jar /usr/share/java/convertwithmoss/convertwithmoss.jar "$@"


### PR DESCRIPTION
- some improvements towards [java package guidelines](https://wiki.archlinux.org/title/Java_package_guidelines)