### PR TITLE
hack: install previous fakeroot version and ignore future updates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,6 +58,7 @@ steps:
     commands:
       - source tools/build-env.sh
       - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring && pacman -Syu --noconfirm
+      - pacman --noconfirm -U https://archive.archlinux.org/packages/f/fakeroot/fakeroot-1.34-1-x86_64.pkg.tar.zst
       - run_nobody tools/clean-build-all.sh
       - if ls -1 out/*-debug-*$PKGEXT 2>/dev/null 1>&2; then
         mv out/*-debug-*$PKGEXT out-debug/; fi

--- a/tools/pacman.conf
+++ b/tools/pacman.conf
@@ -1,3 +1,6 @@
 [proaudio]
 SigLevel = Never
 Server = https://arch.osamc.de/$repo/$arch
+
+[options]
+IgnorePkg = fakeroot


### PR DESCRIPTION
Since update to fakeroot 1.35-1 it hangs when running `makepkg` in docker during CI builds.