### PR TITLE
faustlive: bump pkgrel to rebuild for latest faust version

### DIFF
--- a/packages/faustlive/PKGBUILD
+++ b/packages/faustlive/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=faustlive
 pkgver=2.5.18
-pkgrel=1
+pkgrel=2
 pkgdesc='Faust prototyping environment'
 arch=(aarch64 x86_64)
 url='https://github.com/grame-cncm/faustlive'


### PR DESCRIPTION
- for some reason there was no sound on the current build