### PR TITLE
audiowmark: prevent ffmpeg in check() from reading stdin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,9 @@ steps:
       - source tools/build-env.sh
       - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring
       - pacman -Syu --noconfirm namcap
-      - 'if [ -n "$PACKAGE" ]; then namcap packages/$PACKAGE/PKGBUILD; else namcap packages/*/PKGBUILD; fi'
+      - if [ -n "$PACKAGE" ]; then
+        namcap packages/$PACKAGE/PKGBUILD;
+        else namcap packages/*/PKGBUILD; fi
     depends_on:
       - Prepare
 
@@ -59,8 +61,8 @@ steps:
       - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring && pacman -Syu --noconfirm
       - pacman --noconfirm -U https://archive.archlinux.org/packages/f/fakeroot/fakeroot-1.34-1-x86_64.pkg.tar.zst
       - run_nobody tools/clean-build-all.sh
-      - 'mv -v out/*-debug-*$PKGEXT out-debug'
-      - exit 0
+      - if ls -1 out/*-debug-*$PKGEXT 2>/dev/null 1>&2; then
+        mv out/*-debug-*$PKGEXT out-debug/; fi
     depends_on:
       - Prepare
 
@@ -88,7 +90,7 @@ steps:
       - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring
       - pacman -Syu --noconfirm namcap
       - cd out
-      - 'if ls -1 *$PKGEXT 2>/dev/null 1>&2; then namcap *$PKGEXT; fi'
+      - if ls -1 *$PKGEXT 2>/dev/null 1>&2; then namcap *$PKGEXT; fi
     depends_on:
       - Build packages
     when:
@@ -311,8 +313,8 @@ steps:
       - source tools/build-env.sh
       - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring && pacman -Syu --noconfirm
       - run_nobody tools/clean-build-all.sh
-      - 'mv -v out/*-debug-*$PKGEXT out-debug'
-      - exit 0
+      - if ls -1 out/*-debug-*$PKGEXT 2>/dev/null 1>&2; then
+        mv out/*-debug-*$PKGEXT out-debug/; fi
     depends_on:
       - Prepare
 

--- a/packages/audiowmark/PKGBUILD
+++ b/packages/audiowmark/PKGBUILD
@@ -35,7 +35,7 @@ build() {
 
 check() {
   cd $pkgname-$pkgver
-  make check
+  make check </dev/null
 }
 
 package() {


### PR DESCRIPTION
- see https://github.com/swesterfeld/audiowmark/issues/72#issuecomment-2564714535
- ffmpeg (used in tests) seems to interpret stdin
- maybe a proper fix would patch the tests to use `ffmpeg -nostdin`