### PR TITLE
[ratatouille.lv2] fix: ensure that everything is built with GCC

### DIFF
--- a/packages/ratatouille.lv2/PKGBUILD
+++ b/packages/ratatouille.lv2/PKGBUILD
@@ -4,7 +4,7 @@
 _name=Ratatouille.lv2
 pkgname=${_name,,}
 pkgver=0.9.7
-pkgrel=1
+pkgrel=2
 pkgdesc='A guitar amp neural model and impulse response loader and mixer LV2 plugin'
 arch=(aarch64 x86_64)
 url="https://github.com/brummer10/$_name"
@@ -20,7 +20,7 @@ _plugin_uri="urn:brummer:ratatouille"
 
 build() {
   cd $_name-v$pkgver
-  make
+  make CXX=g++
 }
 
 check() {


### PR DESCRIPTION
See: https://github.com/brummer10/Ratatouille.lv2/issues/42