### PR TITLE
vcvrack-sicko-cv: fix v2.7.1 tag

### DIFF
--- a/packages/vcvrack-sicko-cv/PKGBUILD
+++ b/packages/vcvrack-sicko-cv/PKGBUILD
@@ -5,7 +5,7 @@ _slug=SickoCV
 _name=SickoCV
 pkgname=vcvrack-sicko-cv
 pkgver=2.7.1
-pkgrel=1
+pkgrel=2
 pkgdesc='SickoCV VCV Rack modules'
 arch=(aarch64 x86_64)
 url='https://github.com/sickozell/SickoCV'
@@ -14,7 +14,7 @@ groups=(pro-audio vcvrack-plugins)
 depends=(gcc-libs vcvrack)
 makedepends=(git simde zstd)
 source=("git+https://github.com/sickozell/$_name#tag=v$pkgver")
-sha256sums=('a3d278e863bb19c2cd48dc0519ce62c6e2c32dee22619d7d33d7c1b5f5a4c78e')
+sha256sums=('cfdc9ea498a25898c48e7f759d4fd9572be63c5315472e902c0c49be3084146f')
 
 prepare() {
   cd $_name


### PR DESCRIPTION
The tag was previously removed and later added again as a new version 🤦