### PR TITLE
Setup basic shared cache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,8 +11,6 @@ steps:
   - name: Prepare
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     commands:
@@ -32,8 +30,6 @@ steps:
   - name: Analyze build scripts
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     commands:
@@ -49,8 +45,6 @@ steps:
   - name: Build packages
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     environment:
@@ -80,8 +74,6 @@ steps:
   - name: Analyze built packages
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     commands:
@@ -100,8 +92,6 @@ steps:
   - name: Reproduce packages
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     environment:
@@ -131,8 +121,6 @@ steps:
   - name: Analyze reproduced packages
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     commands:
@@ -225,8 +213,6 @@ steps:
   - name: Push to AUR
     image: archlinux/archlinux:base-devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     environment:
@@ -247,10 +233,8 @@ steps:
         include:
           - refs/heads/master
 
-# use a shared pacman cache to speed up successive package installs
+# a shared package cache should be provided by the CI runner under $DRONE_CACHE
 volumes:
-  - name: pkgcache
-    temp: {}
   - name: pkgdb
     temp: {}
 
@@ -275,8 +259,6 @@ steps:
   - name: Prepare
     image: lopsided/archlinux-arm64v8:devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     failure: ignore # arm64 is not critical for now
@@ -300,8 +282,6 @@ steps:
   - name: Build packages
     image: lopsided/archlinux-arm64v8:devel
     volumes:
-      - name: pkgcache
-        path: /var/cache/pacman/pkg
       - name: pkgdb
         path: /var/lib/pacman/sync
     environment:
@@ -403,10 +383,8 @@ steps:
         include:
           - refs/heads/master
 
-# use a shared pacman cache to speed up successive package installs
+# a shared package cache should be provided by the CI runner under $DRONE_CACHE
 volumes:
-  - name: pkgcache
-    temp: {}
   - name: pkgdb
     temp: {}
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ steps:
         path: /var/lib/pacman/sync
     commands:
       - source tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring
       - pacman -Syu --noconfirm namcap
       - if [ -n "$PACKAGE" ]; then
         namcap packages/$PACKAGE/PKGBUILD;
@@ -58,7 +58,7 @@ steps:
       PKGDEST: /drone/src/out
     commands:
       - source tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring && pacman -Syu --noconfirm
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring && pacman -Syu --noconfirm
       - run_nobody tools/clean-build-all.sh
       - if ls -1 out/*-debug-*$PKGEXT 2>/dev/null 1>&2; then
         mv out/*-debug-*$PKGEXT out-debug/; fi
@@ -86,7 +86,7 @@ steps:
         path: /var/lib/pacman/sync
     commands:
       - source tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring
       - pacman -Syu --noconfirm namcap
       - cd out
       - if ls -1 *$PKGEXT 2>/dev/null 1>&2; then namcap *$PKGEXT; fi
@@ -110,7 +110,7 @@ steps:
     commands:
       - sleep 9 # backoff to prevent false positives
       - source ./tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring && pacman -Syu --noconfirm
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring && pacman -Syu --noconfirm
       - run_nobody tools/clean-build-all.sh
     depends_on:
       - Prepare
@@ -137,7 +137,7 @@ steps:
         path: /var/lib/pacman/sync
     commands:
       - source tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring
       - pacman -Syu --noconfirm diffoscope unzip
       - run_nobody ./tools/diff-packages.sh
     depends_on:
@@ -234,7 +234,7 @@ steps:
         from_secret: ssh-key
     commands:
       - source tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring
       - pacman -Syu --noconfirm git openssh
       - echo "$${SSH_KEY}" > aur/.ssh/id_osamc
       - cp -a aur/.ssh /root && chmod 600 /root/.ssh/*
@@ -310,7 +310,7 @@ steps:
       MAKEFLAGS: -j1
     commands:
       - source tools/build-env.sh
-      - pacman -Sy && pacman-key --init && pacman -S --noconfirm archlinux-keyring && pacman -Syu --noconfirm
+      - pacman -Sy && pacman-key --init && pacman -S --noconfirm --needed archlinux-keyring && pacman -Syu --noconfirm
       - run_nobody tools/clean-build-all.sh
       - if ls -1 out/*-debug-*$PKGEXT 2>/dev/null 1>&2; then
         mv out/*-debug-*$PKGEXT out-debug/; fi

--- a/packages/jamulus/PKGBUILD
+++ b/packages/jamulus/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=jamulus
 pkgname=(jamulus jamulus-headless)
 pkgver=3.11.0
-pkgrel=2
+pkgrel=1
 pkgdesc="Internet jam session software"
 arch=(aarch64 x86_64)
 url='https://jamulus.io/'

--- a/packages/jamulus/PKGBUILD
+++ b/packages/jamulus/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=jamulus
 pkgname=(jamulus jamulus-headless)
 pkgver=3.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Internet jam session software"
 arch=(aarch64 x86_64)
 url='https://jamulus.io/'

--- a/tools/build-env.sh
+++ b/tools/build-env.sh
@@ -5,7 +5,7 @@ if [ -z $CI ]; then
 fi
 
 cat tools/pacman.conf >> /etc/pacman.conf
-echo "CacheDir = ${DRONE_CACHE:-/var/cache}/pacman/pkg" >> /etc/pacman.conf
+echo "CacheDir = ${DRONE_CACHE:-/var/cache}/pacman/pkg/" >> /etc/pacman.conf
 cat tools/makepkg.conf >> /etc/makepkg.conf
 
 source /etc/makepkg.conf

--- a/tools/build-env.sh
+++ b/tools/build-env.sh
@@ -5,6 +5,7 @@ if [ -z $CI ]; then
 fi
 
 cat tools/pacman.conf >> /etc/pacman.conf
+echo "CacheDir = ${DRONE_CACHE:-/var/cache}/pacman/pkg" >> /etc/pacman.conf
 cat tools/makepkg.conf >> /etc/makepkg.conf
 
 source /etc/makepkg.conf

--- a/tools/prepare-build.sh
+++ b/tools/prepare-build.sh
@@ -32,7 +32,9 @@ sudo pacman-key --init
 echo "Updating pacman keyring..."
 sudo pacman -S --noconfirm archlinux-keyring
 echo "Updating installed and installing extra packages..."
-sudo pacman -Syyu --noconfirm git $PACMAN_EXTRA
+sudo pacman -Syyu --noconfirm git pacman-contrib $PACMAN_EXTRA
+echo "Cleaning shared cache..."
+sudo paccache -rk1
 
 # some helpers
 enable_pkgs() {

--- a/tools/prepare-build.sh
+++ b/tools/prepare-build.sh
@@ -30,7 +30,7 @@ sudo pacman -Sy
 echo "Initializing pacman keyring"
 sudo pacman-key --init
 echo "Updating pacman keyring..."
-sudo pacman -S --noconfirm archlinux-keyring
+sudo pacman -S --noconfirm --needed archlinux-keyring
 echo "Updating installed and installing extra packages..."
 sudo pacman -Syyu --noconfirm git pacman-contrib $PACMAN_EXTRA
 echo "Cleaning shared cache..."

--- a/tools/prepare-build.sh
+++ b/tools/prepare-build.sh
@@ -66,8 +66,7 @@ final() {
     "$ROOT"/tools/syncdeps-all.sh $MAKEPKG_ARGS
 
     # Save pacman cache
-    sudo mkdir -p "$CACHE"/{pkgcache,pkgdb}
-    sudo cp -r /var/cache/pacman/pkg/* "$CACHE"/pkgcache
+    sudo mkdir -p "$CACHE"/pkgdb
     sudo cp -r /var/lib/pacman/sync/* "$CACHE"/pkgdb
 
     # print report


### PR DESCRIPTION
This integrates a persisted host cache configured on the CI runners by setting these config variables:
```
DRONE_RUNNER_VOLUMES=/var/cache/drone:/drone/cache
DRONE_RUNNER_ENVIRON=DRONE_CACHE:/drone/cache
```
tbf I don't know yet how well this is going to work out since my CI runners currently don't have huge storage, but let's see...