### PR TITLE
vcvrack-dbrack-sequencer: fix nvchecker

### DIFF
--- a/packages/vcvrack-dbrack-sequencer/.nvchecker.toml
+++ b/packages/vcvrack-dbrack-sequencer/.nvchecker.toml
@@ -3,3 +3,4 @@ source = "github"
 github = "docb/dbRackSequencer"
 use_max_tag = true
 prefix = "v"
+include_regex = '^v[\.\d]+$'


### PR DESCRIPTION
This fixes reporting versions like `v2.6.2-dev`