### PR TITLE
[abcm2ps] fix: build with current GCC

### DIFF
--- a/packages/abcm2ps/PKGBUILD
+++ b/packages/abcm2ps/PKGBUILD
@@ -9,20 +9,28 @@
 
 pkgname=abcm2ps
 pkgver=8.14.15
-pkgrel=1
+pkgrel=2
 pkgdesc='Convert ABC music notation files to PostScript from the command line'
 arch=(x86_64 aarch64)
 url='http://moinejf.free.fr/'
-license=(GPL3)
+license=(GPL-3.0-or-later)
 depends=(glibc)
 makedepends=(freetype2 glib2 pango python-docutils)
 checkdepends=(adobe-source-han-sans-cn-fonts)
 groups=(abc pro-audio)
-source=("$pkgname-$pkgver.tar.gz::https://github.com/lewdlime/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('5f02ac6203c4226cfbc6206935dca715ed7c45328535ee23e776c9da0219c822')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/lewdlime/$pkgname/archive/v$pkgver.tar.gz"
+        'abcm2ps-include-strings.patch')
+sha256sums=('5f02ac6203c4226cfbc6206935dca715ed7c45328535ee23e776c9da0219c822'
+            'b1dde4683a4cc16eadb7d8bfd53859eb58b32699136e657bdb0f5009a591352d')
+
+prepare() {
+  cd $pkgname-$pkgver
+  patch -p1 -N -r -  -i "$srcdir"/abcm2ps-include-strings.patch
+}
 
 build() {
   cd $pkgname-$pkgver
+  export CFLAGS+=" -std=c99 -D_POSIX_C_SOURCE=200809L"
   ./configure --prefix=/usr
   make
 }
@@ -35,7 +43,7 @@ check() {
 
 package() {
   depends+=(libpangocairo-1.0.so libpangoft2-1.0.so libpango-1.0.so
-            libgobject-2.0.so libglib-2.0.so libfreetype.so)
+            libglib-2.0.so libfreetype.so)
   cd $pkgname-$pkgver
   make prefix="$pkgdir"/usr docdir="$pkgdir"s/usr/share/doc install
 }

--- a/packages/abcm2ps/abcm2ps-include-strings.patch
+++ b/packages/abcm2ps/abcm2ps-include-strings.patch
@@ -1,0 +1,44 @@
+diff -uNr abcm2ps-8.14.15.orig/abcparse.c abcm2ps-8.14.15/abcparse.c
+--- abcm2ps-8.14.15.orig/abcparse.c	2024-01-08 08:15:18.000000000 +0100
++++ abcm2ps-8.14.15/abcparse.c	2026-04-14 10:57:59.399925144 +0200
+@@ -16,6 +16,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <ctype.h>
+ 
+ #include "abcm2ps.h"
+diff -uNr abcm2ps-8.14.15.orig/format.c abcm2ps-8.14.15/format.c
+--- abcm2ps-8.14.15.orig/format.c	2024-01-08 08:15:18.000000000 +0100
++++ abcm2ps-8.14.15/format.c	2026-04-14 10:57:59.401497235 +0200
+@@ -14,6 +14,7 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <ctype.h>
+ 
+ #include "abcm2ps.h"
+diff -uNr abcm2ps-8.14.15.orig/front.c abcm2ps-8.14.15/front.c
+--- abcm2ps-8.14.15.orig/front.c	2024-01-08 08:15:18.000000000 +0100
++++ abcm2ps-8.14.15/front.c	2026-04-14 10:57:59.401852525 +0200
+@@ -14,6 +14,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <ctype.h>
+ #include <regex.h>
+ 
+diff -uNr abcm2ps-8.14.15.orig/parse.c abcm2ps-8.14.15/parse.c
+--- abcm2ps-8.14.15.orig/parse.c	2024-01-08 08:15:18.000000000 +0100
++++ abcm2ps-8.14.15/parse.c	2026-04-14 10:54:10.539829418 +0200
+@@ -15,6 +15,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <time.h>
+ #include <ctype.h>
+ #include <regex.h>


### PR DESCRIPTION
* Use CFLAGS '-std=c9 -D_POSIX_C_SOURCE=200809L'
* Include 'strings.h' where missing
* Remove unused .so depends
* Update license field

Obsoletes: #790

Thanks to @HugoNikanor for heads up and original fix!