### PR TITLE
neuralrack: add neuralrack-vst3 subpackage

### DIFF
--- a/packages/neuralrack/PKGBUILD
+++ b/packages/neuralrack/PKGBUILD
@@ -3,9 +3,9 @@
 
 _name=NeuralRack
 pkgbase=${_name,,}
-pkgname=($pkgbase $pkgbase-{clap,lv2,standalone,vst})
+pkgname=($pkgbase $pkgbase-{clap,lv2,standalone,vst,vst3})
 pkgver=0.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc='A neural model and impulse response file loader'
 arch=(aarch64 x86_64)
 url="https://github.com/brummer10/$_name"
@@ -59,12 +59,13 @@ package_neuralrack() {
   make DESTDIR="$pkgdir" install
   install -vDm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
   cd "$pkgdir"
-  rm -rf $pkgbase-{clap,lv2,standalone,vst}
+  rm -rf $pkgbase-{clap,lv2,standalone,vst,vst3}
   _pick $pkgbase-clap usr/lib/clap/*
   _pick $pkgbase-lv2 usr/lib/lv2/*
   _pick $pkgbase-standalone usr/bin/*
   _pick $pkgbase-standalone usr/share/{applications,pixmaps}
   _pick $pkgbase-vst usr/lib/vst/*
+  _pick $pkgbase-vst3 usr/lib/vst3/*
 }
 
 package_neuralrack-clap() {
@@ -103,6 +104,17 @@ package_neuralrack-vst() {
   depends+=(libcairo.so libsndfile.so)
   optdepends=('vst-host: for loading the VST2 plugin')
   groups+=(vst-plugins)
+  mv -v $pkgname/* "$pkgdir"
+  cd $_name-v$pkgver
+  install -vDm 644 README.md $_name.png -t "$pkgdir"/usr/share/doc/$pkgname
+  install -vDm 644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
+}
+
+package_neuralrack-vst3() {
+  pkgdesc+=" – VST3"
+  depends+=(libcairo.so libsndfile.so)
+  optdepends=('vst3-host: for loading the VST3 plugin')
+  groups+=(vst3-plugins)
   mv -v $pkgname/* "$pkgdir"
   cd $_name-v$pkgver
   install -vDm 644 README.md $_name.png -t "$pkgdir"/usr/share/doc/$pkgname


### PR DESCRIPTION
Previously, the neuralrack meta package included vst3 binaries. This PR extracts them into a proper subpackage.