### PR TITLE
jack_transport_link: use vercmp instead of parse_version

### DIFF
--- a/packages/jack_transport_link/.nvchecker.toml
+++ b/packages/jack_transport_link/.nvchecker.toml
@@ -2,4 +2,5 @@
 source = "github"
 github = "x37v/jack_transport_link"
 use_max_tag = true
+sort_version_key = "vercmp"
 prefix = "v"


### PR DESCRIPTION
- nvchecker would detect older releases as more recent due to upstream's messed up versioning scheme, see #850 